### PR TITLE
Prevent HTTPS from checking certificate hostname

### DIFF
--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -189,6 +189,7 @@ export class RPCAgent {
         path: pathname,
         method: METHOD,
         agent: this._agent,
+        checkServerIdentity: () => undefined,
         headers: {
           Accept: "application/json, text/plain, */*",
           "User-Agent": userAgent,


### PR DESCRIPTION
Fixes the bug which means Chia-Agent cannot connect to remote daemon's due to the `ERR_TLS_CERT_ALTNAME_INVALID` error as referenced in #20 