### PR TITLE
Reject promise on connect error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [14.2.1]
+### Changed
+- `daemon.connect()` now returns a rejected promise on failure to connect instead of throwing an uncaught exception
+
 ## [14.2.0]
 ### Note
 - [`add_private_key`](./src/api/ws/daemon/README.md#add_private_keydaemon-params)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-agent",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "author": "ChiaMineJP <admin@chiamine.jp>",
   "description": "chia rpc/websocket client library",
   "license": "MIT",

--- a/src/daemon/connection.ts
+++ b/src/daemon/connection.ts
@@ -50,5 +50,6 @@ export function open(url: string, timeoutMs?: number): Promise<{ ws: WS, openEve
         resolve({ws, openEvent});
       }
     };
+    ws.onerror = (err) => reject(err);
   });
 }


### PR DESCRIPTION
**The problem**

If you try to connect to a daemon that isn't running an uncaught exception is thrown.

```
node:events:497
      throw er; // Unhandled 'error' event
      ^

Error: socket hang up
    at TLSSocket.socketOnEnd (node:_http_client:519:23)
    at TLSSocket.emit (node:events:531:35)
    at endReadableNT (node:internal/streams/readable:1696:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on WebSocket instance at:
    at emitErrorAndClose (/Users/freddiecoleman/code/daemon-test/node_modules/ws/lib/websocket.js:1041:13)
    at ClientRequest.<anonymous> (/Users/freddiecoleman/code/daemon-test/node_modules/ws/lib/websocket.js:881:5)
    at ClientRequest.emit (node:events:519:28)
    at TLSSocket.socketOnEnd (node:_http_client:519:9)
    at TLSSocket.emit (node:events:531:35)
    at endReadableNT (node:internal/streams/readable:1696:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  code: 'ECONNRESET'
}
```

It is currently not possible to catch this error with code such as;

```
try {
    await daemon.connect("wss://localhost:55400");
} catch (err) {
    console.log("err", err);
}
```

**The fix**

We listen for the `onerror` event of the websocket connection and reject the promise used by connect. This makes it possible to catch the error.
