### PR TITLE
Add Host header to RPC requests.

### DIFF
--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -270,6 +270,7 @@ export class RPCAgent implements APIAgent {
         method: METHOD,
         agent: this._agent,
         headers: {
+          Host: this._agent.options.host,
           Accept: "application/json, text/plain, */*",
           "User-Agent": userAgent,
         } as OutgoingHttpHeaders,


### PR DESCRIPTION
Need a Host header for some servers to accept the request. For example, this is necessary to make requests to api.coinset.org