### PR TITLE
v16.1.6: Support chia-blockchain 2.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [16.1.6]
+### Changed
+- Confirmed compatibility with [`chia-blockchain@2.5.6`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.5.6)
+  - chia-blockchain 2.5.6 does not introduce any RPC/Websocket API changes.
+    The only protocol-level change (`NewSignagePointHarvester2`) is a farmer-harvester internal network message
+    which is not part of the API surface covered by chia-agent.
+
 ## [16.1.5]
 ### Fixed
 - Added missing `create_block_generator` to the Full Node RPC API

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![npm version](https://badge.fury.io/js/chia-agent.svg)](https://badge.fury.io/js/chia-agent) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 chia rpc/websocket client library for NodeJS.  
-Supports all RPC/Websocket API available at `2.5.5` of [`chia-blockchain`](https://github.com/Chia-Network/chia-blockchain/).  
+Supports all RPC/Websocket API available at `2.5.6` of [`chia-blockchain`](https://github.com/Chia-Network/chia-blockchain/).  
 \(If you need previous version, search for the corresponding release [here](https://github.com/Chia-Mine/chia-agent/releases)\)
 
 you can develop your own nodejs script with `chia-agent` to:
@@ -22,8 +22,8 @@ yarn add chia-agent
 
 ## Compatibility
 This code is compatible with:  
-- [`c7aafcfb46ef1413b05cdd6486308e99ee4767df`](https://github.com/Chia-Network/chia-blockchain/tree/c7aafcfb46ef1413b05cdd6486308e99ee4767df) of [chia-blockchain 2.5.5](https://github.com/Chia-Network/chia-blockchain)  
-  - [Diff to the main branch of chia-blockchain](https://github.com/Chia-Network/chia-blockchain/compare/c7aafcfb46ef1413b05cdd6486308e99ee4767df...main)
+- [`f546dfca6d68ec4b5df9b11a1ebcb56b32094e66`](https://github.com/Chia-Network/chia-blockchain/tree/f546dfca6d68ec4b5df9b11a1ebcb56b32094e66) of [chia-blockchain 2.5.6](https://github.com/Chia-Network/chia-blockchain)  
+  - [Diff to the main branch of chia-blockchain](https://github.com/Chia-Network/chia-blockchain/compare/f546dfca6d68ec4b5df9b11a1ebcb56b32094e66...main)
 - [`061bd6e192ceb90e3bb81ceff1fc69d674626eb7`](https://github.com/Chia-Network/chia_rs/tree/061bd6e192ceb90e3bb81ceff1fc69d674626eb7) of [chia_rs 0.27.0](https://github.com/Chia-Network/chia_rs)
   - [Diff to the main branch of chia_rs](https://github.com/Chia-Network/chia_rs/compare/061bd6e192ceb90e3bb81ceff1fc69d674626eb7...main)
 - [`ef49150171cc243b09c0e5d5cb27f2249ffa3793`](https://github.com/Chia-Network/pool-reference/tree/ef49150171cc243b09c0e5d5cb27f2249ffa3793) of [pool-reference](https://github.com/Chia-Network/pool-reference)  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-agent",
-  "version": "16.1.5",
+  "version": "16.1.6",
   "author": "ChiaMineJP <admin@chiamine.jp>",
   "description": "chia rpc/websocket client library",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Stacked PR 1/6 (base: `main`) — brings chia-agent to **chia-blockchain 2.5.6**.

chia-blockchain 2.5.6 introduces no RPC/Websocket API changes. The only protocol-level change upstream (`NewSignagePointHarvester2`) is a farmer-harvester internal network message outside chia-agent's API surface, so this is a compatibility-confirmation release:

- Updated README compatibility section to chia-blockchain `2.5.6` (`f546dfc`)
- CHANGELOG entry
- Version bump to `16.1.6`

## Stack
1. **→ this PR** — v16.1.6 (chia 2.5.6)
2. v17.0.0 (chia 2.5.7)
3. v18.0.0 (chia 2.6.0)
4. v19.0.0 (chia 2.6.1)
5. v19.1.0 (chia 2.7.0)
6. v19.2.0 (chia 2.7.1)

## Verification
`pnpm build`, `pnpm check:lint` and `pnpm check:prettier` all pass. (jest integration tests require a live chia installation and are not runnable in this environment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)