### PR TITLE
v17.0.0: Support chia-blockchain 2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## [17.0.0]
+Support for [`chia-blockchain@2.5.7`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.5.7)
+
+### Breaking change
+- The following deprecated DID Wallet RPC APIs were removed (removed in chia-blockchain 2.5.7):
+  - `did_update_recovery_ids`
+  - `did_recovery_spend`
+  - `did_get_recovery_list`
+  - `did_create_attest`
+  - `did_get_information_needed_for_recovery`
+- `TransactionRecord` wire format changed (chia-blockchain 2.5.7 now serializes transaction records
+  with plain `to_json_dict()`; the previous "convenience" format was removed)
+  - `memos` is now `Record<str, bytes[]>` (`{"0x<coin_id>": ["0x<memo>", ...]}`), previously `Array<[bytes32, bytes[]]>`
+  - `to_address` is now a regular field of `TransactionRecord`
+  - `TransactionRecordConvenience` and `TransactionRecordConvenienceWithMetadata` are deprecated aliases of
+    `TransactionRecord` and the new `TransactionRecordWithMetadata`
+- [`get_block_spends_with_conditions`](./src/api/rpc/full_node/README.md#get_block_spends_with_conditionsagent-params)
+  - `conditions` are now serialized as `Array<[opcode: int, args: bytes[]]>` instead of `{opcode, vars}` objects
+- `create_new_wallet` with `wallet_type: "did_wallet"` and `did_type: "new"` no longer accepts
+  `backup_dids` / `num_of_backup_ids_needed`
+- `cat_spend`: `extra_delta` is now `str` (was `int`)
+- Wallet responses of `get_wallets` / `get_wallet_balance(s)` now always include previously-omitted keys
+  (`fingerprint`, `asset_id`, `pending_approval_balance`, `authorized_providers`, `flags_needed`) with `null` defaults,
+  and serialize `bytes`-like values as `0x`-prefixed hex
+
+### Added
+- New `solver` RPC service support (introduced in chia-blockchain 2.5.7)
+  - [`get_state`](./src/api/rpc/solver/README.md#get_stateagent)
+  - `RPCAgent` now accepts `service: "solver"`
+  - `chia_solver` was added to daemon `TService`
+- New Farmer RPC API [`connect_to_solver`](./src/api/rpc/farmer/README.md#connect_to_solveragent-params)
+- `add_key`: new optional `label` request parameter
+- `get_farmed_amount`: new optional `include_pool_rewards` request parameter
+- [Harvester Protocol](./src/api/chia/protocols/harvester_protocol.ts): added `PartialProofsData`
+- New [Solver Protocol](./src/api/chia/protocols/solver_protocol.ts): `SolverInfo`, `SolverResponse`
+- `NodeType`: added `SOLVER = 8`
+
+### Changed
+- Synchronized `chia_rs` type definitions with `chia_rs@0.30.0`
+  - `SpendConditions`: added `fingerprint`
+  - `SpendBundleConditions`: added `num_atoms`, `num_pairs`, `heap_size`
+- `send_notification`: `amount` is now optional (defaults to 0)
+- `spend_clawback_coins`: `batch_size` is now optional `uint16`
+- `get_transactions`: `start` / `end` are now `uint16`
+- `get_next_address`: `new_address` is now optional
+- `cat_asset_id_to_name`: unknown asset ids now resolve to `{wallet_id: null, name: null}` instead of an error
+- `verify_signature`: `error` key is now always present (`null` on success)
+
 ## [16.1.6]
 ### Changed
 - Confirmed compatibility with [`chia-blockchain@2.5.6`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.5.6)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![npm version](https://badge.fury.io/js/chia-agent.svg)](https://badge.fury.io/js/chia-agent) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 chia rpc/websocket client library for NodeJS.  
-Supports all RPC/Websocket API available at `2.5.6` of [`chia-blockchain`](https://github.com/Chia-Network/chia-blockchain/).  
+Supports all RPC/Websocket API available at `2.5.7` of [`chia-blockchain`](https://github.com/Chia-Network/chia-blockchain/).  
 \(If you need previous version, search for the corresponding release [here](https://github.com/Chia-Mine/chia-agent/releases)\)
 
 you can develop your own nodejs script with `chia-agent` to:
-- retrieve latest data from RPC servers like `farmer`, `harvester`, `full_node`, `wallet`, `pool`, `data_layer`, `crawler`.
+- retrieve latest data from RPC servers like `farmer`, `harvester`, `full_node`, `wallet`, `pool`, `data_layer`, `crawler`, `solver`.
 - send email when proof is found.
 - trigger scripts when target event is observed.
 - start/stop services.
@@ -22,10 +22,10 @@ yarn add chia-agent
 
 ## Compatibility
 This code is compatible with:  
-- [`f546dfca6d68ec4b5df9b11a1ebcb56b32094e66`](https://github.com/Chia-Network/chia-blockchain/tree/f546dfca6d68ec4b5df9b11a1ebcb56b32094e66) of [chia-blockchain 2.5.6](https://github.com/Chia-Network/chia-blockchain)  
-  - [Diff to the main branch of chia-blockchain](https://github.com/Chia-Network/chia-blockchain/compare/f546dfca6d68ec4b5df9b11a1ebcb56b32094e66...main)
-- [`061bd6e192ceb90e3bb81ceff1fc69d674626eb7`](https://github.com/Chia-Network/chia_rs/tree/061bd6e192ceb90e3bb81ceff1fc69d674626eb7) of [chia_rs 0.27.0](https://github.com/Chia-Network/chia_rs)
-  - [Diff to the main branch of chia_rs](https://github.com/Chia-Network/chia_rs/compare/061bd6e192ceb90e3bb81ceff1fc69d674626eb7...main)
+- [`54bdf378c7a2a60b45b8d8523dd7b10920f029b8`](https://github.com/Chia-Network/chia-blockchain/tree/54bdf378c7a2a60b45b8d8523dd7b10920f029b8) of [chia-blockchain 2.5.7](https://github.com/Chia-Network/chia-blockchain)  
+  - [Diff to the main branch of chia-blockchain](https://github.com/Chia-Network/chia-blockchain/compare/54bdf378c7a2a60b45b8d8523dd7b10920f029b8...main)
+- [`aea3188b55305aed9ecea7b09a77d063f9f0ace7`](https://github.com/Chia-Network/chia_rs/tree/aea3188b55305aed9ecea7b09a77d063f9f0ace7) of [chia_rs 0.30.0](https://github.com/Chia-Network/chia_rs)
+  - [Diff to the main branch of chia_rs](https://github.com/Chia-Network/chia_rs/compare/aea3188b55305aed9ecea7b09a77d063f9f0ace7...main)
 - [`ef49150171cc243b09c0e5d5cb27f2249ffa3793`](https://github.com/Chia-Network/pool-reference/tree/ef49150171cc243b09c0e5d5cb27f2249ffa3793) of [pool-reference](https://github.com/Chia-Network/pool-reference)  
   - [Diff to the main branch of pool-reference](https://github.com/Chia-Network/pool-reference/compare/ef49150171cc243b09c0e5d5cb27f2249ffa3793...main)
 
@@ -34,7 +34,7 @@ There are 2 kinds of APIs in chia.
 `RPC API` and `Websocket API`.
 
 ### RPC API
-RPC API is used to send message directly to chia services like `farmer`, `harvester`, `full_node`, `wallet`, `data_layer`, `crawler`.
+RPC API is used to send message directly to chia services like `farmer`, `harvester`, `full_node`, `wallet`, `data_layer`, `crawler`, `solver`.
 
 RPC API is just an async function in a traditional request/response style.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-agent",
-  "version": "16.1.6",
+  "version": "17.0.0",
   "author": "ChiaMineJP <admin@chiamine.jp>",
   "description": "chia rpc/websocket client library",
   "license": "MIT",

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -5,7 +5,7 @@ There are 2 kinds of APIs in chia.
 
 ### RPC API
 RPC API is used to send message directly to chia services like `farmer`, `harvester`, `full_node`,
-`wallet`, `data_layer`, `crawler`.
+`wallet`, `data_layer`, `crawler`, `solver`.
 
 RPC API is just an async function with a traditional request/response style.
 
@@ -37,6 +37,7 @@ In order to keep description simple, the above error response is omitted in RPC 
 - [`get_harvester_plots_keys_missing`](./rpc/farmer/README.md#get_harvester_plots_keys_missingagent-params)
 - [`get_harvester_plots_duplicates`](./rpc/farmer/README.md#get_harvester_plots_duplicatesagent-params)
 - [`get_pool_login_link`](./rpc/farmer/README.md#get_pool_login_linkagent-params)
+- [`connect_to_solver`](./rpc/farmer/README.md#connect_to_solveragent-params)
 
 #### [Full Node RPC API](./rpc/full_node/README.md#usage)
 - [`get_blockchain_state`](./rpc/full_node/README.md#get_blockchain_stateagent)
@@ -156,15 +157,10 @@ In order to keep description simple, the above error response is omitted in RPC 
 - [`cancel_offers`](./rpc/wallet/README.md#cancel_offersagent-params)
 - [`did_set_wallet_name`](./rpc/wallet/README.md#did_set_wallet_nameagent-params)
 - [`did_get_wallet_name`](./rpc/wallet/README.md#did_get_wallet_nameagent-params)
-- [`did_update_recovery_ids`](./rpc/wallet/README.md#did_update_recovery_idsagent-params)
 - [`did_update_metadata`](./rpc/wallet/README.md#did_update_metadataagent-params)
 - [`did_get_pubkey`](./rpc/wallet/README.md#did_get_pubkeyagent-params)
 - [`did_get_did`](./rpc/wallet/README.md#did_get_didagent-params)
-- [`did_recovery_spend`](./rpc/wallet/README.md#did_recovery_spendagent-params)
-- [`did_get_recovery_list`](./rpc/wallet/README.md#did_get_recovery_listagent-params)
 - [`did_get_metadata`](./rpc/wallet/README.md#did_get_metadataagent-params)
-- [`did_create_attest`](./rpc/wallet/README.md#did_create_attestagent-params)
-- [`did_get_information_needed_for_recovery`](./rpc/wallet/README.md#did_get_information_needed_for_recoveryagent-params)
 - [`did_get_current_coin_info`](./rpc/wallet/README.md#did_get_current_coin_infoagent-params)
 - [`did_create_backup_file`](./rpc/wallet/README.md#did_create_backup_fileagent-params)
 - [`did_transfer_did`](./rpc/wallet/README.md#did_transfer_didagent-params)
@@ -257,6 +253,9 @@ In order to keep description simple, the above error response is omitted in RPC 
 #### [Crawler RPC API](./rpc/crawler/README.md#usage)
 - [`get_peer_counts`](./rpc/crawler/README.md#get_peer_countsagent)
 - [`get_ips_after_timestamp`](./rpc/crawler/README.md#get_ips_after_timestampagent-params)
+
+#### [Solver RPC API](./rpc/solver/README.md#usage)
+- [`get_state`](./rpc/solver/README.md#get_stateagent)
 
 #### [Common RPC API](./rpc/common/README.md#usage)
 - [`get_network_info`](./rpc/common/README.md#get_network_infoagent)

--- a/src/api/chia/protocols/harvester_protocol.ts
+++ b/src/api/chia/protocols/harvester_protocol.ts
@@ -1,7 +1,19 @@
-import { Optional, str } from "../types/_python_types_";
+import { bytes, Optional, str } from "../types/_python_types_";
 import { G1Element } from "../../chia_rs/chia-bls/lib";
 import { uint64, uint8 } from "../../chia_rs/wheel/python/sized_ints";
 import { bytes32 } from "../../chia_rs/wheel/python/sized_bytes";
+
+export type PartialProofsData = {
+  challenge_hash: bytes32;
+  sp_hash: bytes32;
+  plot_identifier: str;
+  partial_proofs: bytes[];
+  signage_point_index: uint8;
+  plot_size: uint8;
+  pool_public_key: Optional<G1Element>;
+  pool_contract_puzzle_hash: Optional<bytes32>;
+  plot_public_key: G1Element;
+};
 
 export type Plot = {
   filename: str;

--- a/src/api/chia/protocols/outbound_message.ts
+++ b/src/api/chia/protocols/outbound_message.ts
@@ -5,4 +5,5 @@ export type NodeType =
   | 4 // TIMELORD
   | 5 // INTRODUCER
   | 6 // WALLET
-  | 7; // DATA_LAYER
+  | 7 // DATA_LAYER
+  | 8; // SOLVER

--- a/src/api/chia/protocols/solver_protocol.ts
+++ b/src/api/chia/protocols/solver_protocol.ts
@@ -1,0 +1,10 @@
+import { bytes } from "../types/_python_types_";
+
+export type SolverInfo = {
+  partial_proof: bytes;
+};
+
+export type SolverResponse = {
+  partial_proof: bytes;
+  proof: bytes;
+};

--- a/src/api/chia/rpc/wallet_request_types.ts
+++ b/src/api/chia/rpc/wallet_request_types.ts
@@ -263,6 +263,7 @@ export type GenerateMnemonicResponse = {
 
 export type AddKeyRequest = {
   mnemonic: str[];
+  label?: Optional<str>;
 };
 
 export type AddKeyResponse = {

--- a/src/api/chia/types/coin_spend.ts
+++ b/src/api/chia/types/coin_spend.ts
@@ -1,7 +1,10 @@
-import { ConditionWithArgs } from "./condition_with_args";
+import { bytes } from "./_python_types_";
+import { int } from "../../chia_rs/wheel/python/sized_ints";
 import { CoinSpend } from "../../chia_rs/chia-protocol/coin_spend";
 
+// As of chia-blockchain 2.5.7, each condition is serialized as a 2-element array of
+// [opcode (int), args (0x-prefixed hex strings)] instead of {opcode, vars} objects.
 export type CoinSpendWithConditions = {
   coin_spend: CoinSpend;
-  conditions: ConditionWithArgs[];
+  conditions: Array<[int, bytes[]]>;
 };

--- a/src/api/chia/wallet/transaction_record.ts
+++ b/src/api/chia/wallet/transaction_record.ts
@@ -25,21 +25,28 @@ export type TransactionRecordOld = {
   trade_id: Optional<bytes32>;
   type: uint32; // # TransactionType
   name: bytes32;
-  memos: Array<[bytes32, bytes[]]>;
+  memos: Record<str, bytes[]>; // Dict[bytes32, List[bytes]] - keys are 0x-prefixed coin ids
 };
 
 export type TransactionRecord = TransactionRecordOld & {
+  to_address: str;
   valid_times: ConditionValidTimes;
 };
 
-export type TransactionRecordConvenience = {
-  to_address: str;
-  memos: Record<str, str>;
-} & TransactionRecord;
+// As of chia-blockchain 2.5.7, RPC responses serialize transaction records with
+// the plain streamable `to_json_dict()`; the previous "convenience" format was removed.
+/** @deprecated Use {@link TransactionRecord} instead */
+export type TransactionRecordConvenience = TransactionRecord;
 
-export type TransactionRecordConvenienceWithMetadata = {
-  metadata: ClawbackMetadata & {
-    coin_id: str;
-    spent: bool;
-  };
-} & TransactionRecordConvenience;
+export type TransactionRecordWithMetadata = TransactionRecord & {
+  metadata: Optional<
+    ClawbackMetadata & {
+      coin_id: str;
+      spent: bool;
+    }
+  >;
+};
+
+/** @deprecated Use {@link TransactionRecordWithMetadata} instead */
+export type TransactionRecordConvenienceWithMetadata =
+  TransactionRecordWithMetadata;

--- a/src/api/chia_rs/chia-consensus/owned_conditions.ts
+++ b/src/api/chia_rs/chia-consensus/owned_conditions.ts
@@ -26,6 +26,9 @@ export type SpendConditions = {
   // per-spend execution and condition cost
   execution_cost: uint64;
   condition_cost: uint64;
+  // the spend's fingerprint. This is "0x" unless the
+  // ELIGIBLE_FOR_DEDUP flag is set
+  fingerprint: bytes;
 };
 
 export type SpendBundleConditions = {
@@ -51,4 +54,7 @@ export type SpendBundleConditions = {
   validated_signature: bool;
   execution_cost: uint64;
   condition_cost: uint64;
+  num_atoms: uint32;
+  num_pairs: uint32;
+  heap_size: uint32;
 };

--- a/src/api/rpc/farmer/README.md
+++ b/src/api/rpc/farmer/README.md
@@ -400,3 +400,30 @@ const response = await get_pool_login_link(agent, params);
   login_link: str;
 }
 ```
+
+---
+
+## `connect_to_solver(agent, params)`
+### Usage
+```js
+const {RPCAgent} = require("chia-agent");
+const {connect_to_solver} = require("chia-agent/api/rpc/farmer");
+const agent = new RPCAgent({service: "farmer"});
+const response = await connect_to_solver(agent, params);
+```
+### params:
+```typescript
+{
+  host: str;
+  port: int;
+}
+```
+### response:
+```typescript
+{
+  success: True;
+} | {
+  success: False;
+  error: str;
+}
+```

--- a/src/api/rpc/farmer/index.ts
+++ b/src/api/rpc/farmer/index.ts
@@ -1,5 +1,11 @@
 import { ProofOfSpace } from "../../chia_rs/chia-protocol/proof_of_space";
-import { bool, Optional, str } from "../../chia/types/_python_types_";
+import {
+  bool,
+  False,
+  Optional,
+  str,
+  True,
+} from "../../chia/types/_python_types_";
 import {
   int,
   uint32,
@@ -386,6 +392,37 @@ export async function get_pool_login_link<T extends TRPCAgent | TDaemon>(
   );
 }
 
+export const connect_to_solver_command = "connect_to_solver";
+export type connect_to_solver_command = typeof connect_to_solver_command;
+export type TConnectToSolverRequest = {
+  host: str;
+  port: int;
+};
+export type TConnectToSolverResponse =
+  | {
+      success: True;
+    }
+  | {
+      success: False;
+      error: str;
+    };
+export type WsConnectToSolverMessage = GetMessageType<
+  chia_farmer_service,
+  connect_to_solver_command,
+  TConnectToSolverResponse
+>;
+export async function connect_to_solver<T extends TRPCAgent | TDaemon>(
+  agent: T,
+  params: TConnectToSolverRequest,
+) {
+  type R = ResType<T, TConnectToSolverResponse, WsConnectToSolverMessage>;
+  return agent.sendMessage<R>(
+    chia_farmer_service,
+    connect_to_solver_command,
+    params,
+  );
+}
+
 export type RpcFarmerMessage =
   | TGetRewardTargetResponse
   | TGetSignagePointResponse
@@ -399,7 +436,8 @@ export type RpcFarmerMessage =
   | TGetHarvesterPlotsDuplicatesResponse
   | TSetPayoutInstructionsResponse
   | TGetPoolStateResponse
-  | TGetPoolLinkResponse;
+  | TGetPoolLinkResponse
+  | TConnectToSolverResponse;
 
 export type RpcFarmerMessageOnWs =
   | WsGetRewardTargetsMessage
@@ -414,4 +452,5 @@ export type RpcFarmerMessageOnWs =
   | WsGetHarvesterPlotsDuplicatesMessage
   | WsSetPayoutInstructionsMessage
   | WsGetPoolStateMessage
-  | WsGetPoolLinkMessage;
+  | WsGetPoolLinkMessage
+  | WsConnectToSolverMessage;

--- a/src/api/rpc/index.ts
+++ b/src/api/rpc/index.ts
@@ -284,9 +284,6 @@ export {
   TDidGetWalletNameRequest,
   TDidGetWalletNameResponse,
   did_get_wallet_name,
-  TDidCreateAttestRequest,
-  TDidCreateAttestResponse,
-  did_create_attest,
   TDidCreateBackupFileRequest,
   TDidCreateBackupFileResponse,
   did_create_backup_file,
@@ -296,30 +293,18 @@ export {
   TDidGetDidRequest,
   TDidGetDidResponse,
   did_get_did,
-  TDidGetInformationNeededForRecoveryRequest,
-  TDidGetInformationNeededForRecoveryResponse,
-  did_get_information_needed_for_recovery,
   TDidGetCurrentCoinInfoRequest,
   TDidGetCurrentCoinInfoResponse,
   did_get_current_coin_info,
   TDidGetPubkeyRequest,
   TDidGetPubkeyResponse,
   did_get_pubkey,
-  TDidGetRecoveryListRequest,
-  TDidGetRecoveryListResponse,
-  did_get_recovery_list,
   TDidGetMetadataRequest,
   TDidGetMetadataResponse,
   did_get_metadata,
-  TDidRecoverySpendRequest,
-  TDidRecoverySpendResponse,
-  did_recovery_spend,
   TDidSpendRequest,
   TDidSpendResponse,
   did_spend,
-  TDidUpdateRecoveryIdsRequest,
-  TDidUpdateRecoveryIdsResponse,
-  did_update_recovery_ids,
   TDidUpdateMetadataRequest,
   TDidUpdateMetadataResponse,
   did_update_metadata,
@@ -648,6 +633,13 @@ export {
   get_peer_counts,
 } from "./crawler/index";
 
+import type { RpcSolverMessage } from "./solver/index";
+export {
+  chia_solver_service,
+  TGetStateResponse,
+  get_state,
+} from "./solver/index";
+
 import type { RpcCommonMessage } from "./common/index";
 export {
   chia_common_service,
@@ -685,4 +677,5 @@ export type RpcMessage =
   | RpcWalletMessage
   | RpcDataLayerMessage
   | RpcCrawlerMessage
+  | RpcSolverMessage
   | RpcCommonMessage;

--- a/src/api/rpc/solver/README.md
+++ b/src/api/rpc/solver/README.md
@@ -1,0 +1,48 @@
+# Solver RPC API
+
+## Usage
+You need to create RPC connection before actually sending rpc request to the service.  
+Please remember that all rpc API is provided as an async function.
+```js
+const {RPCAgent} = require("chia-agent");
+const {get_state} = require("chia-agent/api/rpc/solver");
+const agent = new RPCAgent({
+  service: "solver", // connect to local solver service using config file.
+});
+// Then call RPC function
+const response = await get_state(agent);
+
+// Once agent is instantiated, you can re-use it everytime you want to request solver API.
+
+
+
+/*
+ * You can instantiate `agent` with hostname/port.
+ * See https://github.com/Chia-Mine/chia-agent/blob/main/src/rpc/index.ts
+ */
+const agent = new RPCAgent({
+  protocol: "https",
+  host: "aaa.bbb.ccc",
+  port: 8667,
+  ca_cert: fs.readFileSync(...),
+  client_cert: fs.readFileSync(...),
+  client_key: fs.readFileSync(...),
+});
+```
+
+---
+
+## `get_state(agent)`
+### Usage
+```js
+const {RPCAgent} = require("chia-agent");
+const {get_state} = require("chia-agent/api/rpc/solver");
+const agent = new RPCAgent({service: "solver"});
+const response = await get_state(agent);
+```
+### response:
+```typescript
+{
+  started: bool;
+}
+```

--- a/src/api/rpc/solver/index.ts
+++ b/src/api/rpc/solver/index.ts
@@ -1,0 +1,26 @@
+import { bool } from "../../chia/types/_python_types_";
+import { TRPCAgent } from "../../../rpc/index";
+import { TDaemon } from "../../../daemon/index";
+import { GetMessageType, ResType } from "../../types";
+
+export const chia_solver_service = "chia_solver";
+export type chia_solver_service = typeof chia_solver_service;
+
+export const get_state_command = "get_state";
+export type get_state_command = typeof get_state_command;
+export type TGetStateResponse = {
+  started: bool;
+};
+export type WsGetStateMessage = GetMessageType<
+  chia_solver_service,
+  get_state_command,
+  TGetStateResponse
+>;
+export async function get_state<T extends TRPCAgent | TDaemon>(agent: T) {
+  type R = ResType<T, TGetStateResponse, WsGetStateMessage>;
+  return agent.sendMessage<R>(chia_solver_service, get_state_command);
+}
+
+export type RpcSolverMessage = TGetStateResponse;
+
+export type RpcSolverMessageOnWs = WsGetStateMessage;

--- a/src/api/rpc/wallet/README.md
+++ b/src/api/rpc/wallet/README.md
@@ -145,6 +145,7 @@ const response = await add_key(agent, params);
 ```typescript
 {
   mnemonic: str[];
+  label?: Optional<str>;
 }
 ```
 ### response:
@@ -870,13 +871,19 @@ see https://github.com/Chia-Mine/chia-agent/blob/main/src/api/chia/wallet/util/q
 
 ---
 
-## `get_farmed_amount(agent)`
+## `get_farmed_amount(agent, params)`
 ### Usage
 ```js
 const {RPCAgent} = require("chia-agent");
 const {get_farmed_amount} = require("chia-agent/api/rpc/wallet");
 const agent = new RPCAgent({service: "wallet"});
-const response = await get_farmed_amount(agent);
+const response = await get_farmed_amount(agent, params);
+```
+### params:
+```typescript
+{
+  include_pool_rewards?: bool;
+}
 ```
 ### response:
 ```typescript
@@ -2067,39 +2074,6 @@ const response = await did_get_wallet_name(agent, params);
 
 ---
 
-## `did_update_recovery_ids(agent, params)`
-### Usage
-```js
-const {RPCAgent} = require("chia-agent");
-const {did_update_recovery_ids} = require("chia-agent/api/rpc/wallet");
-const agent = new RPCAgent({service: "wallet"});
-const response = await did_update_recovery_ids(agent, params);
-```
-### params:
-```typescript
-{
-  wallet_id: uint32;
-  new_list: str[];
-  num_verifications_required?: uint64;
-} & TXEndpointRequest
-```
-### response:
-```typescript
-{
-  success: bool;
-  transactions: TransactionRecordConvenience[];
-  unsigned_transactions: UnsignedTransaction[] | str[];
-  signing_responses?: str[];
-}
-```
-For content of `TransactionRecordConvenience`,  
-see https://github.com/Chia-Mine/chia-agent/blob/main/src/api/chia/wallet/transaction_record.ts
-
-For content of `TXEndpointRequest` and `UnsignedTransaction`  
-see https://github.com/Chia-Mine/chia-agent/blob/main/src/api/chia/rpc/util.ts
-
----
-
 ## `did_update_metadata(agent, params)`
 ### Usage
 ```js
@@ -2190,68 +2164,6 @@ const response = await did_get_did(agent, params);
 
 ---
 
-## `did_recovery_spend(agent, params)`
-### Usage
-```js
-const {RPCAgent} = require("chia-agent");
-const {did_recovery_spend} = require("chia-agent/api/rpc/wallet");
-const agent = new RPCAgent({service: "wallet"});
-const response = await did_recovery_spend(agent, params);
-```
-### params:
-```typescript
-{
-  wallet_id: uint32;
-  attest_data: str[];
-  pubkey?: str;
-  puzhash?: str;
-  push?: bool;
-}
-```
-### response:
-```typescript
-{
-  success: True;
-  spend_bundle: SpendBundle;
-  transactions: TransactionRecordConvenience[];
-} | {
-  success: False;
-  reason: str;
-}
-```
-For content of `SpendBundle`,  
-see https://github.com/Chia-Mine/chia-agent/blob/main/src/api/chia_rs/chia-protocol/spend_bundle.ts
-
-For content of `TransactionRecordConvenience`,  
-see https://github.com/Chia-Mine/chia-agent/blob/main/src/api/chia/wallet/transaction_record.ts
-
----
-
-## `did_get_recovery_list(agent, params)`
-### Usage
-```js
-const {RPCAgent} = require("chia-agent");
-const {did_get_recovery_list} = require("chia-agent/api/rpc/wallet");
-const agent = new RPCAgent({service: "wallet"});
-const response = await did_get_recovery_list(agent, params);
-```
-### params:
-```typescript
-{
-  wallet_id: uint32;
-}
-```
-### response:
-```typescript
-{
-  wallet_id: uint32;
-  recovery_list: str[];
-  num_required: uint64;
-}
-```
-
----
-
 ## `did_get_metadata(agent, params)`
 ### Usage
 ```js
@@ -2272,72 +2184,6 @@ const response = await did_get_metadata(agent, params);
   success: True;
   wallet_id: uint32;
   metadata: Record<str, str>
-}
-```
-
----
-
-## `did_create_attest(agent, params)`
-### Usage
-```js
-const {RPCAgent} = require("chia-agent");
-const {did_create_attest} = require("chia-agent/api/rpc/wallet");
-const agent = new RPCAgent({service: "wallet"});
-const response = await did_create_attest(agent, params);
-```
-### params:
-```typescript
-{
-  wallet_id: uint32;
-  coin_name: str;
-  puzhash: str;
-} & TXEndpointRequest
-```
-### response:
-```typescript
-{
-  success: True;
-  message_spend_bundle: str;
-  info: [str, str, uint64];
-  attest_data: str;
-  transactions: TransactionRecordConvenience[];
-  unsigned_transactions: UnsignedTransaction[] | str[];
-  signing_responses?: str[];
-} | {
-  success: False;
-}
-```
-For content of `TransactionRecordConvenience`,  
-see https://github.com/Chia-Mine/chia-agent/blob/main/src/api/chia/wallet/transaction_record.ts
-
-For content of `TXEndpointRequest` and `UnsignedTransaction`  
-see https://github.com/Chia-Mine/chia-agent/blob/main/src/api/chia/rpc/util.ts
-
----
-
-## `did_get_information_needed_for_recovery(agent, params)`
-### Usage
-```js
-const {RPCAgent} = require("chia-agent");
-const {did_get_information_needed_for_recovery} = require("chia-agent/api/rpc/wallet");
-const agent = new RPCAgent({service: "wallet"});
-const response = await did_get_information_needed_for_recovery(agent, params);
-```
-### params:
-```typescript
-{
-  wallet_id: uint32;
-}
-```
-### response:
-```typescript
-{
-  wallet_id: uint32;
-  my_did: str;
-  coin_name: str;
-  newpuzhash: Optional<bytes32>;
-  pubkey: Optional<bytes>;
-  backup_dids: bytes[];
 }
 ```
 

--- a/src/api/rpc/wallet/index.ts
+++ b/src/api/rpc/wallet/index.ts
@@ -22,7 +22,6 @@ import {
   TransactionRecordConvenience,
   TransactionRecordConvenienceWithMetadata,
 } from "../../chia/wallet/transaction_record";
-import { SpendBundle } from "../../chia_rs/chia-protocol/spend_bundle";
 import { TRPCAgent } from "../../../rpc";
 import { PoolWalletInfo } from "../../chia/pools/pool_wallet_info";
 import { TradeRecordConvenience } from "../../chia/wallet/trade_record";
@@ -529,9 +528,13 @@ export type TGetWalletsRequest = {
   type?: int;
   include_data?: bool;
 };
+export type WalletInfoResponse = WalletInfo & {
+  authorized_providers: bytes32[];
+  flags_needed: str[];
+};
 export type TGetWalletsResponse = {
-  wallets: WalletInfo[];
-  fingerprint?: int;
+  wallets: WalletInfoResponse[];
+  fingerprint: Optional<uint32>;
 };
 export type WsGetWalletsMessage = GetMessageType<
   chia_wallet_service,
@@ -574,8 +577,6 @@ export type TCreateNewDidWalletRequestNew = {
   fee?: uint64;
   wallet_type: "did_wallet";
   did_type: "new";
-  backup_dids: str[];
-  num_of_backup_ids_needed: uint64;
   amount: int;
   metadata?: Record<str, str>;
   wallet_name?: str;
@@ -719,8 +720,9 @@ export async function create_new_wallet<
 export type WalletBalance = Balance & {
   wallet_id: uint32;
   wallet_type: int;
-  fingerprint?: int;
-  asset_id?: str;
+  fingerprint: Optional<uint32>;
+  asset_id: Optional<str>; // 0x-prefixed hex
+  pending_approval_balance: Optional<uint64>;
 };
 export const get_wallet_balance_command = "get_wallet_balance";
 export type get_wallet_balance_command = typeof get_wallet_balance_command;
@@ -802,8 +804,8 @@ export const get_transactions_command = "get_transactions";
 export type get_transactions_command = typeof get_transactions_command;
 export type TGetTransactionsRequest = {
   wallet_id: int;
-  start?: int;
-  end?: int;
+  start?: uint16;
+  end?: uint16;
   sort_key?: str;
   reverse?: bool;
   to_address?: str;
@@ -834,7 +836,7 @@ export async function get_transactions<T extends TRPCAgent | TDaemon>(
 export const get_next_address_command = "get_next_address";
 export type get_next_address_command = typeof get_next_address_command;
 export type TGetNextAddressRequest = {
-  new_address: bool;
+  new_address?: bool;
   wallet_id: int;
 };
 export type TGetNextAddressResponse = {
@@ -860,13 +862,17 @@ export async function get_next_address<T extends TRPCAgent | TDaemon>(
 
 export const send_transaction_command = "send_transaction";
 export type send_transaction_command = typeof send_transaction_command;
+export type ClawbackPuzzleDecoratorOverride = {
+  decorator: "CLAWBACK";
+  clawback_timelock: uint64;
+};
 export type TSendTransactionRequest = {
   wallet_id: uint32;
   amount: int;
   fee?: uint64;
   address: str;
   memos?: str[];
-  puzzle_decorator?: Array<{ decorator: str; clawback_timelock?: uint64 }>;
+  puzzle_decorator?: ClawbackPuzzleDecoratorOverride[];
 } & TXEndpointRequest;
 export type TSendTransactionResponse = {
   transaction: TransactionRecordConvenience;
@@ -926,7 +932,7 @@ export type spend_clawback_coins_command = typeof spend_clawback_coins_command;
 export type TSpendClawbackCoinsRequest = {
   coin_ids: str[];
   fee?: uint64;
-  batch_size: int;
+  batch_size?: uint16;
   force?: bool;
 } & TXEndpointRequest;
 export type TSpendClawbackCoinsResponse = {
@@ -1026,11 +1032,19 @@ export type WsGetFarmedAmountMessage = GetMessageType<
   get_farmed_amount_command,
   TGetFarmedAmountResponse
 >;
+export type TGetFarmedAmountRequest = {
+  include_pool_rewards?: bool;
+};
 export async function get_farmed_amount<T extends TRPCAgent | TDaemon>(
   agent: T,
+  data?: TGetFarmedAmountRequest,
 ) {
   type R = ResType<T, TGetFarmedAmountResponse, WsGetFarmedAmountMessage>;
-  return agent.sendMessage<R>(chia_wallet_service, get_farmed_amount_command);
+  return agent.sendMessage<R>(
+    chia_wallet_service,
+    get_farmed_amount_command,
+    data,
+  );
 }
 
 export type TAdditions = {
@@ -1312,7 +1326,7 @@ export type send_notification_command = typeof send_notification_command;
 export type TSendNotificationRequest = {
   target: str;
   message: str;
-  amount: uint64;
+  amount?: uint64; // defaults to 0
   fee?: uint64;
 } & TXEndpointRequest;
 export type TSendNotificationResponse = {
@@ -1350,6 +1364,7 @@ export type TVerifySignatureRequest = {
 export type TVerifySignatureResponse =
   | {
       isValid: True;
+      error: None;
     }
   | {
       isValid: False;
@@ -1563,7 +1578,7 @@ export type TCatAssetIdToNameRequest = {
 };
 export type TCatAssetIdToNameResponse = {
   wallet_id: Optional<uint32>;
-  name: str;
+  name: Optional<str>; // null when the asset id is unknown (no longer errors)
 };
 export type WsCatAssetIdToNameMessage = GetMessageType<
   chia_wallet_service,
@@ -1629,12 +1644,12 @@ export type cat_spend_command = typeof cat_spend_command;
 export type TCatSpendRequest = {
   wallet_id: uint32;
   additions?: TAdditions[];
-  fee: uint64;
-  amount: uint64;
-  inner_address: str;
+  fee?: uint64;
+  amount?: uint64;
+  inner_address?: str;
   memos?: str[];
   coins?: Coin[];
-  extra_delta?: int;
+  extra_delta?: str; // changed from int to str in chia-blockchain 2.5.7
   tail_reveal?: str;
   tail_solution?: str;
 } & TXEndpointRequest;
@@ -1999,37 +2014,6 @@ export async function did_get_wallet_name<T extends TRPCAgent | TDaemon>(
   );
 }
 
-export const did_update_recovery_ids_command = "did_update_recovery_ids";
-export type did_update_recovery_ids_command =
-  typeof did_update_recovery_ids_command;
-export type TDidUpdateRecoveryIdsRequest = {
-  wallet_id: uint32;
-  new_list: str[];
-  num_verifications_required?: uint64;
-} & TXEndpointRequest;
-export type TDidUpdateRecoveryIdsResponse = {
-  success: bool;
-  transactions: TransactionRecordConvenience[];
-  signing_responses?: str[];
-};
-export type WsDidUpdateRecoveryIdsMessage<R> = GetMessageType<
-  chia_wallet_service,
-  did_update_recovery_ids_command,
-  R
->;
-export async function did_update_recovery_ids<
-  T extends TRPCAgent | TDaemon,
-  D extends TDidUpdateRecoveryIdsRequest,
->(agent: T, data: D) {
-  type TER = TxeResp<D, TDidUpdateRecoveryIdsResponse>;
-  type R = ResType<T, TER, WsDidUpdateRecoveryIdsMessage<TER>>;
-  return agent.sendMessage<R>(
-    chia_wallet_service,
-    did_update_recovery_ids_command,
-    data,
-  );
-}
-
 export const did_update_metadata_command = "did_update_metadata";
 export type did_update_metadata_command = typeof did_update_metadata_command;
 export type TDidUpdateMetadataRequest = {
@@ -2133,71 +2117,6 @@ export async function did_get_did<T extends TRPCAgent | TDaemon>(
   return agent.sendMessage<R>(chia_wallet_service, did_get_did_command, data);
 }
 
-export const did_recovery_spend_command = "did_recovery_spend";
-export type did_recovery_spend_command = typeof did_recovery_spend_command;
-export type TDidRecoverySpendRequest = {
-  wallet_id: uint32;
-  attest_data: str[];
-  pubkey?: str;
-  puzhash?: str;
-  push?: bool;
-};
-export type TDidRecoverySpendResponse =
-  | {
-      success: True;
-      spend_bundle: SpendBundle;
-      transactions: TransactionRecordConvenience[];
-    }
-  | {
-      success: False;
-      reason: str;
-    };
-export type WsDidRecoverySpendMessage = GetMessageType<
-  chia_wallet_service,
-  did_recovery_spend_command,
-  TDidRecoverySpendResponse
->;
-export async function did_recovery_spend<T extends TRPCAgent | TDaemon>(
-  agent: T,
-  data: TDidRecoverySpendRequest,
-) {
-  type R = ResType<T, TDidRecoverySpendResponse, WsDidRecoverySpendMessage>;
-  return agent.sendMessage<R>(
-    chia_wallet_service,
-    did_recovery_spend_command,
-    data,
-  );
-}
-
-export const did_get_recovery_list_command = "did_get_recovery_list";
-export type did_get_recovery_list_command =
-  typeof did_get_recovery_list_command;
-export type TDidGetRecoveryListRequest = {
-  wallet_id: uint32;
-};
-export type TDidGetRecoveryListResponse = {
-  success: bool;
-  wallet_id: uint32;
-  recovery_list: str[];
-  num_required: uint64;
-};
-export type WsDidGetRecoveryListMessage = GetMessageType<
-  chia_wallet_service,
-  did_get_recovery_list_command,
-  TDidGetRecoveryListResponse
->;
-export async function did_get_recovery_list<T extends TRPCAgent | TDaemon>(
-  agent: T,
-  data: TDidGetRecoveryListRequest,
-) {
-  type R = ResType<T, TDidGetRecoveryListResponse, WsDidGetRecoveryListMessage>;
-  return agent.sendMessage<R>(
-    chia_wallet_service,
-    did_get_recovery_list_command,
-    data,
-  );
-}
-
 export const did_get_metadata_command = "did_get_metadata";
 export type did_get_metadata_command = typeof did_get_metadata_command;
 export type TDidGetMetadataRequest = {
@@ -2221,79 +2140,6 @@ export async function did_get_metadata<T extends TRPCAgent | TDaemon>(
   return agent.sendMessage<R>(
     chia_wallet_service,
     did_get_metadata_command,
-    data,
-  );
-}
-
-export const did_create_attest_command = "did_create_attest";
-export type did_create_attest_command = typeof did_create_attest_command;
-export type TDidCreateAttestRequest = {
-  wallet_id: uint32;
-  coin_name: str;
-  puzhash: str;
-} & TXEndpointRequest;
-export type TDidCreateAttestResponse =
-  | {
-      success: True;
-      message_spend_bundle: str;
-      info: [str, str, uint64];
-      attest_data: str;
-      transactions: TransactionRecordConvenience[];
-      signing_responses?: str[];
-    }
-  | {
-      success: False;
-    };
-export type WsDidCreateAttestMessage<R> = GetMessageType<
-  chia_wallet_service,
-  did_create_attest_command,
-  R
->;
-export async function did_create_attest<
-  T extends TRPCAgent | TDaemon,
-  D extends TDidCreateAttestRequest,
->(agent: T, data: D) {
-  type TER = TxeResp<D, TDidCreateAttestResponse>;
-  type R = ResType<T, TER, WsDidCreateAttestMessage<TER>>;
-  return agent.sendMessage<R>(
-    chia_wallet_service,
-    did_create_attest_command,
-    data,
-  );
-}
-
-export const did_get_information_needed_for_recovery_command =
-  "did_get_information_needed_for_recovery";
-export type did_get_information_needed_for_recovery_command =
-  typeof did_get_information_needed_for_recovery_command;
-export type TDidGetInformationNeededForRecoveryRequest = {
-  wallet_id: uint32;
-};
-export type TDidGetInformationNeededForRecoveryResponse = {
-  success: bool;
-  wallet_id: uint32;
-  my_did: str;
-  coin_name: str;
-  newpuzhash: Optional<bytes32>;
-  pubkey: Optional<bytes>;
-  backup_dids: bytes[];
-};
-export type WsDidGetInformationNeededForRecoveryMessage = GetMessageType<
-  chia_wallet_service,
-  did_get_information_needed_for_recovery_command,
-  TDidGetInformationNeededForRecoveryResponse
->;
-export async function did_get_information_needed_for_recovery<
-  T extends TRPCAgent | TDaemon,
->(agent: T, data: TDidGetInformationNeededForRecoveryRequest) {
-  type R = ResType<
-    T,
-    TDidGetInformationNeededForRecoveryResponse,
-    WsDidGetInformationNeededForRecoveryMessage
-  >;
-  return agent.sendMessage<R>(
-    chia_wallet_service,
-    did_get_information_needed_for_recovery_command,
     data,
   );
 }
@@ -3881,21 +3727,16 @@ export type RpcWalletMessage =
   | TCheckDeleteKeyResponse
   | TDidSetWalletNameResponse
   | TDidGetWalletNameResponse
-  | TDidCreateAttestResponse
   | TDidCreateBackupFileResponse
   | TDidTransferDidResponse
   | TDidMessageSpendResponse
   | TDidGetInfoResponse
   | TDidFindLostDidResponse
   | TDidGetDidResponse
-  | TDidGetInformationNeededForRecoveryResponse
   | TDidGetCurrentCoinInfoResponse
   | TDidGetPubkeyResponse
-  | TDidGetRecoveryListResponse
   | TDidGetMetadataResponse
-  | TDidRecoverySpendResponse
   | TDidSpendResponse
-  | TDidUpdateRecoveryIdsResponse
   | TDidUpdateMetadataResponse
   | TNftMintNftResponse
   | TNftCountNftsResponse

--- a/src/api/ws/daemon/index.ts
+++ b/src/api/ws/daemon/index.ts
@@ -44,7 +44,8 @@ export type TService =
   | "chia_introducer"
   | "chia_timelord"
   | "chia_timelord_launcher"
-  | "chia_full_node_simulator";
+  | "chia_full_node_simulator"
+  | "chia_solver";
 export const start_service_command = "start_service";
 export type start_service_command = typeof start_service_command;
 export type TStartServiceRequest = {

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -41,6 +41,7 @@ type TDestination =
   | "full_node"
   | "wallet"
   | "data_layer"
+  | "solver"
   | "daemon"
   | "pool";
 
@@ -62,6 +63,8 @@ export function getConnectionInfoFromConfig(
     port = +(config["/wallet/rpc_port"] as string);
   } else if (destination === "data_layer") {
     port = +(config["/data_layer/rpc_port"] as string);
+  } else if (destination === "solver") {
+    port = +(config["/solver/rpc_port"] as string);
   } else if (destination === "pool") {
     const poolUrl = config["/pool/pool_list/0/pool_url"] as string;
     const regex = /^(https?:\/\/)?([^/:]+):?(\d*)/;


### PR DESCRIPTION
## Summary
Stacked PR 2/6 (base: `v16.1.6`, see #81) — brings chia-agent to **chia-blockchain 2.5.7**. Major version bump due to upstream breaking changes.

### Breaking
- Removed the 5 deprecated DID recovery Wallet RPCs (`did_update_recovery_ids`, `did_recovery_spend`, `did_get_recovery_list`, `did_create_attest`, `did_get_information_needed_for_recovery`)
- `TransactionRecord` wire format: upstream removed the "convenience" serialization — `memos` is now `Record<str, bytes[]>` (`{"0x<coin_id>": ["0x<memo>", ...]}`), `to_address` is a regular field. `TransactionRecordConvenience(WithMetadata)` remain as deprecated aliases
- full_node `get_block_spends_with_conditions`: conditions are now `[opcode, args[]]` tuples instead of `{opcode, vars}` objects
- `create_new_wallet` (DID new): `backup_dids` / `num_of_backup_ids_needed` removed
- `cat_spend.extra_delta` is now `str`
- `get_wallets` / `get_wallet_balance(s)` responses always include previously-omitted nullable keys; bytes values are 0x-prefixed

### Added
- New **solver** RPC service (`get_state`), `RPCAgent({service: "solver"})`, `chia_solver` daemon service name, solver protocol types, `NodeType.SOLVER = 8`
- Farmer RPC `connect_to_solver`
- `add_key.label`, `get_farmed_amount.include_pool_rewards`
- Harvester protocol `PartialProofsData`
- chia_rs 0.30.0 type sync (`SpendConditions.fingerprint`, `SpendBundleConditions.num_atoms/num_pairs/heap_size`)

See the `[17.0.0]` CHANGELOG entry for the full list.

## Verification
`pnpm build`, `pnpm check:lint` and `pnpm check:prettier` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)