### PR TITLE
v18.0.0: Support chia-blockchain 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## [18.0.0]
+Support for [`chia-blockchain@2.6.0`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.6.0)
+
+### Breaking change
+- `create_new_wallet`
+  - The response `type` is now the `WalletType` name string (`"CAT"`, `"DECENTRALIZED_ID"`, `"NFT"`, `"POOLING_WALLET"`)
+    instead of the integer enum value
+  - Pool wallet `mode: "recovery"` was removed
+  - Pool wallet response now includes `type`
+  - `asset_id`, `coin_name`, `newpuzhash`, `pubkey`, `launcher_id` and `p2_singleton_puzzle_hash` in responses
+    are now `0x`-prefixed hex
+  - The `{success: false, error: "invalid request"}` success-path variant was removed
+    (invalid requests now produce a standard RPC error response)
+- `get_offer_summary`
+  - `summary.offered` / `summary.requested` amounts are now JSON strings (were numbers)
+  - `additions` / `removals` are now `0x`-prefixed hex
+  - DataLayer offer summaries are now typed as `TDataLayerOfferSummary`
+- `create_signed_transaction` / `send_transaction_multi`
+  - Per-announcement `morph_bytes` was removed; only the top-level `morph_bytes` is applied
+- All transaction endpoints now require a fully synced wallet
+  (may fail with `"Wallet needs to be fully synced before making transactions."`)
+- `split_coins` with `number_of_coins == 0` and `combine_coins` with `number_of_coins < 2` now error
+
+### Added
+- [Harvester Protocol](./src/api/chia/protocols/harvester_protocol.ts)
+  - `PartialProofsData`: `partial_proofs` is now `PartialProof[]`; added `strength` and `plot_id`
+  - `Plot`: added `compression_level`; for v2 plots `size` now encodes `0x80 | strength`
+- [Solver Protocol](./src/api/chia/protocols/solver_protocol.ts)
+  - `SolverInfo` is now `{partial_proof: PartialProof, plot_id, strength, size}`
+  - `SolverResponse.partial_proof` is now `PartialProof`
+- Added `PartialProof` type (mirrors `chia_rs`)
+
+### Changed
+- Synchronized `chia_rs` type definitions with `chia_rs@0.35.2`
+  - `SubEpochSummary`: added `challenge_merkle_root`
+  - `RewardChainBlock`: added `header_mmr_root`
+- `create_offer_for_ids`: `offer` dictionary values are canonically strings now (`Record<str, str | int>`)
+- `get_transactions`: `start` / `end` widened to `uint32`
+- `get_all_offers`: `start` / `end` are now bounded to `uint16`
+
 ## [17.0.0]
 Support for [`chia-blockchain@2.5.7`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.5.7)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![npm version](https://badge.fury.io/js/chia-agent.svg)](https://badge.fury.io/js/chia-agent) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 chia rpc/websocket client library for NodeJS.  
-Supports all RPC/Websocket API available at `2.5.7` of [`chia-blockchain`](https://github.com/Chia-Network/chia-blockchain/).  
+Supports all RPC/Websocket API available at `2.6.0` of [`chia-blockchain`](https://github.com/Chia-Network/chia-blockchain/).  
 \(If you need previous version, search for the corresponding release [here](https://github.com/Chia-Mine/chia-agent/releases)\)
 
 you can develop your own nodejs script with `chia-agent` to:
@@ -22,10 +22,10 @@ yarn add chia-agent
 
 ## Compatibility
 This code is compatible with:  
-- [`54bdf378c7a2a60b45b8d8523dd7b10920f029b8`](https://github.com/Chia-Network/chia-blockchain/tree/54bdf378c7a2a60b45b8d8523dd7b10920f029b8) of [chia-blockchain 2.5.7](https://github.com/Chia-Network/chia-blockchain)  
-  - [Diff to the main branch of chia-blockchain](https://github.com/Chia-Network/chia-blockchain/compare/54bdf378c7a2a60b45b8d8523dd7b10920f029b8...main)
-- [`aea3188b55305aed9ecea7b09a77d063f9f0ace7`](https://github.com/Chia-Network/chia_rs/tree/aea3188b55305aed9ecea7b09a77d063f9f0ace7) of [chia_rs 0.30.0](https://github.com/Chia-Network/chia_rs)
-  - [Diff to the main branch of chia_rs](https://github.com/Chia-Network/chia_rs/compare/aea3188b55305aed9ecea7b09a77d063f9f0ace7...main)
+- [`a73171a119f27d3e94409f1a523207fd151b4b69`](https://github.com/Chia-Network/chia-blockchain/tree/a73171a119f27d3e94409f1a523207fd151b4b69) of [chia-blockchain 2.6.0](https://github.com/Chia-Network/chia-blockchain)  
+  - [Diff to the main branch of chia-blockchain](https://github.com/Chia-Network/chia-blockchain/compare/a73171a119f27d3e94409f1a523207fd151b4b69...main)
+- [`a1d5fbcb15a12e3b5bde96d633e2e5419d7632f0`](https://github.com/Chia-Network/chia_rs/tree/a1d5fbcb15a12e3b5bde96d633e2e5419d7632f0) of [chia_rs 0.35.2](https://github.com/Chia-Network/chia_rs)
+  - [Diff to the main branch of chia_rs](https://github.com/Chia-Network/chia_rs/compare/a1d5fbcb15a12e3b5bde96d633e2e5419d7632f0...main)
 - [`ef49150171cc243b09c0e5d5cb27f2249ffa3793`](https://github.com/Chia-Network/pool-reference/tree/ef49150171cc243b09c0e5d5cb27f2249ffa3793) of [pool-reference](https://github.com/Chia-Network/pool-reference)  
   - [Diff to the main branch of pool-reference](https://github.com/Chia-Network/pool-reference/compare/ef49150171cc243b09c0e5d5cb27f2249ffa3793...main)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-agent",
-  "version": "17.0.0",
+  "version": "18.0.0",
   "author": "ChiaMineJP <admin@chiamine.jp>",
   "description": "chia rpc/websocket client library",
   "license": "MIT",

--- a/src/api/chia/protocols/harvester_protocol.ts
+++ b/src/api/chia/protocols/harvester_protocol.ts
@@ -1,15 +1,18 @@
-import { bytes, Optional, str } from "../types/_python_types_";
+import { Optional, str } from "../types/_python_types_";
 import { G1Element } from "../../chia_rs/chia-bls/lib";
 import { uint64, uint8 } from "../../chia_rs/wheel/python/sized_ints";
 import { bytes32 } from "../../chia_rs/wheel/python/sized_bytes";
+import { PartialProof } from "../../chia_rs/chia-protocol/partial_proof";
 
 export type PartialProofsData = {
   challenge_hash: bytes32;
   sp_hash: bytes32;
   plot_identifier: str;
-  partial_proofs: bytes[];
+  partial_proofs: PartialProof[];
   signage_point_index: uint8;
   plot_size: uint8;
+  strength: uint8;
+  plot_id: bytes32;
   pool_public_key: Optional<G1Element>;
   pool_contract_puzzle_hash: Optional<bytes32>;
   plot_public_key: G1Element;
@@ -17,6 +20,7 @@ export type PartialProofsData = {
 
 export type Plot = {
   filename: str;
+  // For v2 plots the MSB is set: value = 0x80 | strength. v1 plots keep the plain k-size.
   size: uint8;
   plot_id: bytes32;
   pool_public_key: Optional<G1Element>;
@@ -24,4 +28,5 @@ export type Plot = {
   plot_public_key: G1Element;
   file_size: uint64;
   time_modified: uint64;
+  compression_level: Optional<uint8>;
 };

--- a/src/api/chia/protocols/solver_protocol.ts
+++ b/src/api/chia/protocols/solver_protocol.ts
@@ -1,10 +1,16 @@
 import { bytes } from "../types/_python_types_";
+import { uint8 } from "../../chia_rs/wheel/python/sized_ints";
+import { bytes32 } from "../../chia_rs/wheel/python/sized_bytes";
+import { PartialProof } from "../../chia_rs/chia-protocol/partial_proof";
 
 export type SolverInfo = {
-  partial_proof: bytes;
+  partial_proof: PartialProof;
+  plot_id: bytes32;
+  strength: uint8;
+  size: uint8;
 };
 
 export type SolverResponse = {
-  partial_proof: bytes;
+  partial_proof: PartialProof;
   proof: bytes;
 };

--- a/src/api/chia_rs/chia-protocol/partial_proof.ts
+++ b/src/api/chia_rs/chia-protocol/partial_proof.ts
@@ -1,0 +1,5 @@
+import { uint64 } from "../wheel/python/sized_ints";
+
+export type PartialProof = {
+  proof_fragments: uint64[]; // 64 entries
+};

--- a/src/api/chia_rs/chia-protocol/reward_chain_block.ts
+++ b/src/api/chia_rs/chia-protocol/reward_chain_block.ts
@@ -30,5 +30,6 @@ export type RewardChainBlock = {
   reward_chain_sp_signature: G2Element; // G2Element
   reward_chain_ip_vdf: VDFInfo; // VDFInfo
   infused_challenge_chain_ip_vdf: Optional<VDFInfo>; // Optional[VDFInfo]  # Iff deficit < 16
+  header_mmr_root: Optional<bytes32>; // Optional[bytes32]  # null until the corresponding fork activates
   is_transaction_block: bool; // bool
 };

--- a/src/api/chia_rs/chia-protocol/sub_epoch_summary.ts
+++ b/src/api/chia_rs/chia-protocol/sub_epoch_summary.ts
@@ -8,4 +8,5 @@ export type SubEpochSummary = {
   num_blocks_overflow: uint8; // uint8  # How many more blocks than 384*(N-1)
   new_difficulty: Optional<uint64>; // Optional[uint64]  # Only once per epoch (diff adjustment)
   new_sub_slot_iters: Optional<uint64>; // Optional[uint64]  # Only once per epoch (diff adjustment)
+  challenge_merkle_root: Optional<bytes32>; // Optional[bytes32]  # null until the corresponding fork activates
 };

--- a/src/api/rpc/wallet/README.md
+++ b/src/api/rpc/wallet/README.md
@@ -502,18 +502,14 @@ type TCreate_New_Pool_WalletRequest = {
   };
   p2_singleton_delayed_ph?: str;
   p2_singleton_delay_time?: uint64;
-} | {
-  fee?: uint64;
-  wallet_type: "pool_wallet";
-  mode: "recovery";
 };
 ```
 ### response:
-One of `TCreate_New_CAT_WalletResponse`, `TCreate_New_DID_WalletResponse`, `TCreate_New_NFT_WalletResponse`, `TCreate_New_Pool_WalletResponse`, `TCreateWalletErrorResponse`
+One of `TCreate_New_CAT_WalletResponse`, `TCreate_New_DID_WalletResponse`, `TCreate_New_NFT_WalletResponse`, `TCreate_New_Pool_WalletResponse`
 ```typescript
 type TCreate_New_CAT_WalletResponse = {
-  type: uint8;
-  asset_id: str;
+  type: "CAT";
+  asset_id: str; // 0x-prefixed hex
   wallet_id: uint32;
   transactions: TransactionRecordConvenience[];
   unsigned_transactions: UnsignedTransaction[] | str[];
@@ -522,12 +518,14 @@ type TCreate_New_CAT_WalletResponse = {
 
 type TCreate_New_DID_WalletResponse = {
   success: true;
-  type: uint8;
+  type: "DECENTRALIZED_ID";
   my_did: str;
   wallet_id: uint32;
+  transactions: TransactionRecordConvenience[];
+  signing_responses?: str[];
 } | {
   success: true;
-  type: uint8;
+  type: "DECENTRALIZED_ID";
   my_did: str;
   wallet_id: uint32;
   coin_name: bytes32;
@@ -540,11 +538,12 @@ type TCreate_New_DID_WalletResponse = {
 
 type TCreate_New_NFT_WalletResponse = {
   success: True;
-  type: uint8;
+  type: "NFT";
   wallet_id: uint32;
 };
 
 type TCreate_New_Pool_WalletResponse = {
+  type: "POOLING_WALLET";
   total_fee: uint64;
   transaction: TransactionRecord;
   launcher_id: str;
@@ -554,10 +553,6 @@ type TCreate_New_Pool_WalletResponse = {
   signing_responses?: str[];
 };
 
-type TCreateWalletErrorResponse = {
-  success: False;
-  error: str;
-};
 ```
 For content of `Coin`,  
 see https://github.com/Chia-Mine/chia-agent/blob/main/src/api/chia_rs/chia-protocol/coin.ts  
@@ -917,7 +912,7 @@ const response = await create_signed_transaction(agent, params);
   coins?: Coin[];
   coin_announcements?: TCoinAnnouncement[];
   puzzle_announcements?: TPuzzleAnnouncement[];
-  morph_bytes?: True;
+  morph_bytes?: str;
 } & TXEndpointRequest
 ```
 ### response:
@@ -1743,7 +1738,7 @@ const response = await create_offer_for_ids(agent, params);
 ### params:
 ```typescript
 {
-  offer: Record<int, int>;
+  offer: Record<str, str | int>;
   fee?: uint64;
   validate_only?: bool;
   driver_dict?: TDriverDict;
@@ -1793,8 +1788,8 @@ const response = await get_offer_summary(agent, params);
 ```typescript
 {
   summary: {
-    offered: Record<str, int>;
-    requested: Record<str, int>;
+    offered: Record<str, str>;
+    requested: Record<str, str>;
     fees: int;
     infos: TDriverDict;
     additions: str[];

--- a/src/api/rpc/wallet/index.ts
+++ b/src/api/rpc/wallet/index.ts
@@ -14,7 +14,6 @@ import {
   uint16,
   uint32,
   uint64,
-  uint8,
 } from "../../chia_rs/wheel/python/sized_ints";
 import { bytes32 } from "../../chia_rs/wheel/python/sized_bytes";
 import {
@@ -566,8 +565,8 @@ export type TCreate_New_CAT_WalletRequest =
     };
 
 export type TCreate_New_CAT_WalletResponse = {
-  type: uint8;
-  asset_id: str;
+  type: "CAT"; // WalletType name string as of chia-blockchain 2.6.0 (was an int)
+  asset_id: str; // 0x-prefixed hex
   wallet_id: uint32;
   transactions: TransactionRecordConvenience[];
   signing_responses?: str[];
@@ -593,19 +592,21 @@ export type TCreate_New_DID_WalletRequest =
   | TCreateNewDidWalletRequestRecovery;
 export type TCreateNewDidWalletResponseNew = {
   success: True;
-  type: uint8;
+  type: "DECENTRALIZED_ID"; // WalletType name string as of chia-blockchain 2.6.0 (was an int)
   my_did: str;
   wallet_id: uint32;
+  transactions: TransactionRecordConvenience[];
+  signing_responses?: str[];
 };
 export type TCreateNewDidWalletResponseRecovery = {
   success: True;
-  type: uint8;
+  type: "DECENTRALIZED_ID"; // WalletType name string as of chia-blockchain 2.6.0 (was an int)
   my_did: str;
   wallet_id: uint32;
-  coin_name: str;
+  coin_name: str; // 0x-prefixed hex
   coin_list: [bytes32, bytes32, uint64]; // Not Coin[]. See as_list function implementation.
-  newpuzhash: str;
-  pubkey: str;
+  newpuzhash: str; // 0x-prefixed hex
+  pubkey: str; // 0x-prefixed hex
   backup_dids: bytes[];
   num_verifications_required: uint64;
 };
@@ -623,46 +624,36 @@ export type TCreate_New_NFT_WalletRequest = {
 
 export type TCreate_New_NFT_WalletResponse = {
   success: True;
-  type: uint8;
+  type: "NFT"; // WalletType name string as of chia-blockchain 2.6.0 (was an int)
   wallet_id: uint32;
 };
 
-export type TCreate_New_Pool_WalletRequest =
-  | {
-      fee?: uint64;
-      wallet_type: "pool_wallet";
-      mode: "new";
-      initial_target_state:
-        | {
-            state: "SELF_POOLING";
-          }
-        | {
-            state: "FARMING_TO_POOL";
-            target_puzzle_hash: str;
-            pool_url: str;
-            relative_lock_height: uint32;
-          };
-      p2_singleton_delayed_ph?: str;
-      p2_singleton_delay_time?: uint64;
-    }
-  | {
-      fee?: uint64;
-      wallet_type: "pool_wallet";
-      mode: "recovery";
-    };
+export type TCreate_New_Pool_WalletRequest = {
+  fee?: uint64;
+  wallet_type: "pool_wallet";
+  mode: "new"; // "recovery" mode was removed in chia-blockchain 2.6.0
+  initial_target_state:
+    | {
+        state: "SELF_POOLING";
+      }
+    | {
+        state: "FARMING_TO_POOL";
+        target_puzzle_hash: str;
+        pool_url: str;
+        relative_lock_height: uint32;
+      };
+  p2_singleton_delayed_ph?: str;
+  p2_singleton_delay_time?: uint64;
+};
 
 export type TCreate_New_Pool_WalletResponse = {
+  type: "POOLING_WALLET"; // WalletType name string as of chia-blockchain 2.6.0
   total_fee: uint64;
   transaction: TransactionRecord;
   transactions: TransactionRecordConvenience[];
   signing_responses?: str[];
-  launcher_id: str;
-  p2_singleton_puzzle_hash: str;
-};
-
-export type TCreateWalletErrorResponse = {
-  success: False;
-  error: str;
+  launcher_id: str; // 0x-prefixed hex
+  p2_singleton_puzzle_hash: str; // 0x-prefixed hex
 };
 
 export const create_new_wallet_command = "create_new_wallet";
@@ -683,8 +674,7 @@ export type TCreateNewWalletResponse =
   | TCreate_New_CAT_WalletResponse
   | TCreate_New_DID_WalletResponse
   | TCreate_New_NFT_WalletResponse
-  | TCreate_New_Pool_WalletResponse
-  | TCreateWalletErrorResponse;
+  | TCreate_New_Pool_WalletResponse;
 
 export type GetCreateNewWalletResponse<REQ extends TCreateNewWalletRequest> =
   REQ extends TCreate_New_CAT_WalletRequest
@@ -804,8 +794,8 @@ export const get_transactions_command = "get_transactions";
 export type get_transactions_command = typeof get_transactions_command;
 export type TGetTransactionsRequest = {
   wallet_id: int;
-  start?: uint16;
-  end?: uint16;
+  start?: uint32;
+  end?: uint32;
   sort_key?: str;
   reverse?: bool;
   to_address?: str;
@@ -1055,12 +1045,10 @@ export type TAdditions = {
 export type TCoinAnnouncement = {
   coin_id: str;
   message: str;
-  morph_bytes?: str;
 };
 export type TPuzzleAnnouncement = {
   puzzle_hash: str;
   message: str;
-  morph_bytes?: str;
 };
 export const create_signed_transaction_command = "create_signed_transaction";
 export type create_signed_transaction_command =
@@ -1072,7 +1060,7 @@ export type TCreateSignedTransactionRequest = {
   coins?: Coin[];
   coin_announcements?: TCoinAnnouncement[];
   puzzle_announcements?: TPuzzleAnnouncement[];
-  morph_bytes?: True;
+  morph_bytes?: str; // hex; applied to every announcement message
 } & TXEndpointRequest;
 export type TCreateSignedTransactionResponse = {
   signed_txs: TransactionRecordConvenience[];
@@ -1702,7 +1690,8 @@ export async function cat_get_asset_id<T extends TRPCAgent | TDaemon>(
 export const create_offer_for_ids_command = "create_offer_for_ids";
 export type create_offer_for_ids_command = typeof create_offer_for_ids_command;
 export type TCreateOfferForIdsRequest = {
-  offer: Record<int, int>;
+  offer: Record<str, str | int>; // values are canonically strings as of chia-blockchain 2.6.0
+
   fee?: uint64;
   validate_only?: bool;
   driver_dict?: TDriverDict;
@@ -1738,22 +1727,34 @@ export type TGetOfferSummaryRequest = {
   offer: str;
   advanced?: bool;
 };
+export type TOfferSummary = {
+  offered: Record<str, str>; // amounts are JSON strings as of chia-blockchain 2.6.0
+  requested: Record<str, str>; // amounts are JSON strings as of chia-blockchain 2.6.0
+  fees: int;
+  infos: TDriverDict;
+  additions: str[]; // 0x-prefixed hex
+  removals: str[]; // 0x-prefixed hex
+  valid_times: Omit<
+    ConditionValidTimes,
+    | "max_secs_after_created"
+    | "min_secs_since_created"
+    | "max_blocks_after_created"
+    | "min_blocks_since_created"
+  >;
+};
+// Returned for DataLayer offers
+export type TDataLayerOfferSummary = {
+  offered: Array<{
+    launcher_id: str; // 0x-prefixed hex
+    new_root: str; // 0x-prefixed hex
+    dependencies: Array<{
+      launcher_id: str; // 0x-prefixed hex
+      values_to_prove: str[]; // 0x-prefixed hex
+    }>;
+  }>;
+};
 export type TGetOfferSummaryResponse = {
-  summary: {
-    offered: Record<str, int>;
-    requested: Record<str, int>;
-    fees: int;
-    infos: TDriverDict;
-    additions: str[];
-    removals: str[];
-    valid_times: Omit<
-      ConditionValidTimes,
-      | "max_secs_after_created"
-      | "min_secs_since_created"
-      | "max_blocks_after_created"
-      | "min_blocks_since_created"
-    >;
-  };
+  summary: TOfferSummary | TDataLayerOfferSummary;
   id: bytes32;
 };
 export type WsGetOfferSummaryMessage = GetMessageType<
@@ -1852,8 +1853,8 @@ export async function get_offer<T extends TRPCAgent | TDaemon>(
 export const get_all_offers_command = "get_all_offers";
 export type get_all_offers_command = typeof get_all_offers_command;
 export type TGetAllOffersRequest = {
-  start?: int;
-  end?: int;
+  start?: uint16;
+  end?: uint16;
   exclude_my_offers?: bool;
   exclude_taken_offers?: bool;
   include_completed?: bool;


### PR DESCRIPTION
## Summary
Stacked PR 3/6 (base: `v17.0.0`, see #82) — brings chia-agent to **chia-blockchain 2.6.0**. Major version bump due to upstream breaking response-format changes.

### Breaking
- `create_new_wallet`: response `type` is now the `WalletType` **name string** (`"CAT"`, `"DECENTRALIZED_ID"`, `"NFT"`, `"POOLING_WALLET"`) instead of the integer enum value; pool `mode: "recovery"` removed; several response hex fields now 0x-prefixed; the `{success: false, error: "invalid request"}` success-path variant removed
- `get_offer_summary`: `offered`/`requested` amounts are now JSON **strings**; `additions`/`removals` 0x-prefixed; DataLayer summary variant typed
- `create_signed_transaction` / `send_transaction_multi`: per-announcement `morph_bytes` removed (top-level only)
- All transaction endpoints now require a fully synced wallet

### Added / Changed
- V2-plot (PoS2) protocol updates: `PartialProofsData` now carries `PartialProof[]` + `strength`/`plot_id`; `Plot.compression_level`; `size` MSB encodes v2 plots
- Solver protocol `SolverInfo`/`SolverResponse` updated to `PartialProof`
- chia_rs 0.35.2 sync: `SubEpochSummary.challenge_merkle_root`, `RewardChainBlock.header_mmr_root`, new `PartialProof`
- `get_transactions.start/end` widened to uint32; `get_all_offers.start/end` bounded to uint16
- `create_offer_for_ids.offer` values canonically strings

See the `[18.0.0]` CHANGELOG entry for the full list.

## Verification
`pnpm build`, `pnpm check:lint` and `pnpm check:prettier` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)