### PR TITLE
v19.0.0: Support chia-blockchain 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [19.0.0]
+Support for [`chia-blockchain@2.6.1`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.6.1)
+
+### Breaking change
+- `ProofOfSpace` type was updated for v2 proof-of-space (follows `chia_rs@0.38.2`)
+  - Added `version`, `plot_index`, `meta_group` and `strength` fields (between `plot_public_key` and `size`)
+  - `size` now only carries the v1 k-size (0 for v2 proofs)
+  - This affects every RPC response embedding a `ProofOfSpace` (e.g. block records)
+- `PartialProof`: `proof_fragments` was renamed to `fragments` (now 16 entries; follows `chia_rs@0.38.2`)
+
+### Added
+- Structured RPC errors (added in chia-blockchain 2.6.1)
+  - RPC error responses now always include `structuredError: {code, message, data}`
+    (and `traceback` on the HTTP RPC path)
+  - `RpcError` now exposes a `structuredError` property
+  - Added `TStructuredError` and `TRpcErrorCode` types
+- `create_signed_transaction`: new optional request parameters
+  `extra_delta`, `tail_reveal`, `tail_solution` (must be specified together) and `puzzle_decorator`
+- [Harvester Protocol](./src/api/chia/protocols/harvester_protocol.ts)
+  - `PartialProofsData`: added `plot_index` and `meta_group`
+
+### Changed
+- Synchronized `chia_rs` type definitions with `chia_rs@0.38.2`
+- `nft_mint_nft`: upstream reverted the `royalty_amount` rename back to `royalty_percentage`
+  (chia-agent already used `royalty_percentage`; no type change)
+- `take_offer`: the `sign` request parameter is now ignored by the wallet (signing is handled internally)
+- `did_find_lost_did`: `latest_coin_id` now echoes the requested coin id
+
 ## [18.0.0]
 Support for [`chia-blockchain@2.6.0`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.6.0)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![npm version](https://badge.fury.io/js/chia-agent.svg)](https://badge.fury.io/js/chia-agent) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 chia rpc/websocket client library for NodeJS.  
-Supports all RPC/Websocket API available at `2.6.0` of [`chia-blockchain`](https://github.com/Chia-Network/chia-blockchain/).  
+Supports all RPC/Websocket API available at `2.6.1` of [`chia-blockchain`](https://github.com/Chia-Network/chia-blockchain/).  
 \(If you need previous version, search for the corresponding release [here](https://github.com/Chia-Mine/chia-agent/releases)\)
 
 you can develop your own nodejs script with `chia-agent` to:
@@ -22,10 +22,10 @@ yarn add chia-agent
 
 ## Compatibility
 This code is compatible with:  
-- [`a73171a119f27d3e94409f1a523207fd151b4b69`](https://github.com/Chia-Network/chia-blockchain/tree/a73171a119f27d3e94409f1a523207fd151b4b69) of [chia-blockchain 2.6.0](https://github.com/Chia-Network/chia-blockchain)  
-  - [Diff to the main branch of chia-blockchain](https://github.com/Chia-Network/chia-blockchain/compare/a73171a119f27d3e94409f1a523207fd151b4b69...main)
-- [`a1d5fbcb15a12e3b5bde96d633e2e5419d7632f0`](https://github.com/Chia-Network/chia_rs/tree/a1d5fbcb15a12e3b5bde96d633e2e5419d7632f0) of [chia_rs 0.35.2](https://github.com/Chia-Network/chia_rs)
-  - [Diff to the main branch of chia_rs](https://github.com/Chia-Network/chia_rs/compare/a1d5fbcb15a12e3b5bde96d633e2e5419d7632f0...main)
+- [`204fe59bd82984ec7c70794891a669a949e3edc3`](https://github.com/Chia-Network/chia-blockchain/tree/204fe59bd82984ec7c70794891a669a949e3edc3) of [chia-blockchain 2.6.1](https://github.com/Chia-Network/chia-blockchain)  
+  - [Diff to the main branch of chia-blockchain](https://github.com/Chia-Network/chia-blockchain/compare/204fe59bd82984ec7c70794891a669a949e3edc3...main)
+- [`da47ae281f1f8801542a743263db84fff3612de1`](https://github.com/Chia-Network/chia_rs/tree/da47ae281f1f8801542a743263db84fff3612de1) of [chia_rs 0.38.2](https://github.com/Chia-Network/chia_rs)
+  - [Diff to the main branch of chia_rs](https://github.com/Chia-Network/chia_rs/compare/da47ae281f1f8801542a743263db84fff3612de1...main)
 - [`ef49150171cc243b09c0e5d5cb27f2249ffa3793`](https://github.com/Chia-Network/pool-reference/tree/ef49150171cc243b09c0e5d5cb27f2249ffa3793) of [pool-reference](https://github.com/Chia-Network/pool-reference)  
   - [Diff to the main branch of pool-reference](https://github.com/Chia-Network/pool-reference/compare/ef49150171cc243b09c0e5d5cb27f2249ffa3793...main)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-agent",
-  "version": "18.0.0",
+  "version": "19.0.0",
   "author": "ChiaMineJP <admin@chiamine.jp>",
   "description": "chia rpc/websocket client library",
   "license": "MIT",

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -17,10 +17,18 @@ See how to instantiate RPCAgent before requesting RPC API [**>>here**](../rpc/RE
 If an exception is raised in RPC server, error response will be returned in the following format:
 ```typescript
 {
-  error: string;
+  error: string; // legacy human-readable message
   success: false;
+  traceback: string; // python traceback (HTTP RPC only)
+  structuredError: {
+    code: string; // one of the RpcErrorCodes strings introduced in chia-blockchain 2.6.1
+    message: string;
+    data: Record<string, unknown>;
+  };
 }
 ```
+`traceback` and `structuredError` were added in chia-blockchain 2.6.1.
+(`traceback` is not included when the request is routed through the daemon websocket)
 In order to keep description simple, the above error response is omitted in RPC API documents below.
 
 #### [Farmer RPC API](./rpc/farmer/README.md#usage)

--- a/src/api/chia/protocols/harvester_protocol.ts
+++ b/src/api/chia/protocols/harvester_protocol.ts
@@ -1,6 +1,6 @@
 import { Optional, str } from "../types/_python_types_";
 import { G1Element } from "../../chia_rs/chia-bls/lib";
-import { uint64, uint8 } from "../../chia_rs/wheel/python/sized_ints";
+import { uint16, uint64, uint8 } from "../../chia_rs/wheel/python/sized_ints";
 import { bytes32 } from "../../chia_rs/wheel/python/sized_bytes";
 import { PartialProof } from "../../chia_rs/chia-protocol/partial_proof";
 
@@ -11,6 +11,8 @@ export type PartialProofsData = {
   partial_proofs: PartialProof[];
   signage_point_index: uint8;
   plot_size: uint8;
+  plot_index: uint16;
+  meta_group: uint8;
   strength: uint8;
   plot_id: bytes32;
   pool_public_key: Optional<G1Element>;

--- a/src/api/chia_rs/chia-protocol/partial_proof.ts
+++ b/src/api/chia_rs/chia-protocol/partial_proof.ts
@@ -1,5 +1,5 @@
 import { uint64 } from "../wheel/python/sized_ints";
 
 export type PartialProof = {
-  proof_fragments: uint64[]; // 64 entries
+  fragments: uint64[]; // 16 entries
 };

--- a/src/api/chia_rs/chia-protocol/proof_of_space.ts
+++ b/src/api/chia_rs/chia-protocol/proof_of_space.ts
@@ -1,13 +1,19 @@
 import { bytes32 } from "../wheel/python/sized_bytes";
 import { bytes, Optional } from "../../chia/types/_python_types_";
 import { G1Element } from "../chia-bls/lib";
-import { uint8 } from "../wheel/python/sized_ints";
+import { uint16, uint8 } from "../wheel/python/sized_ints";
 
 export type ProofOfSpace = {
   challenge: bytes32; // byte32
   pool_public_key: Optional<G1Element>; // Optional[G1Element]
   pool_contract_puzzle_hash: Optional<bytes32>; // Optional[bytes32]
   plot_public_key: G1Element; // G1Element
-  size: uint8; // uint8 // The original name of `size` is `version_and_size` in chia-rs, so in the future we may change it to `version_and_size`
+  version: uint8; // uint8 // 0 for v1 proof-of-space and 1 for v2
+  // These are set for v2 proofs and all zero for v1 proofs
+  plot_index: uint16; // uint16
+  meta_group: uint8; // uint8
+  strength: uint8; // uint8
+  // this is set for v1 proofs, and zero for v2 proofs
+  size: uint8; // uint8
   proof: bytes; // bytes
 };

--- a/src/api/rpc/wallet/index.ts
+++ b/src/api/rpc/wallet/index.ts
@@ -1061,6 +1061,11 @@ export type TCreateSignedTransactionRequest = {
   coin_announcements?: TCoinAnnouncement[];
   puzzle_announcements?: TPuzzleAnnouncement[];
   morph_bytes?: str; // hex; applied to every announcement message
+  // The following three must be specified together or not at all
+  extra_delta?: str;
+  tail_reveal?: str; // hex
+  tail_solution?: str; // hex
+  puzzle_decorator?: ClawbackPuzzleDecoratorOverride[];
 } & TXEndpointRequest;
 export type TCreateSignedTransactionResponse = {
   signed_txs: TransactionRecordConvenience[];

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -25,13 +25,78 @@ const JSONbig = JSONbigBuilder({
   alwaysParseAsBig: false,
 });
 
+// One of the `RpcErrorCodes` values introduced in chia-blockchain 2.6.1
+export type TRpcErrorCode =
+  | "API_ERROR"
+  | "BLOCK_DOES_NOT_EXIST"
+  | "BLOCK_HASH_NOT_FOUND"
+  | "BLOCK_HEIGHT_NOT_FOUND"
+  | "BLOCK_IN_FORK"
+  | "BLOCK_NOT_FOUND"
+  | "COIN_RECORD_NOT_FOUND"
+  | "CONSENSUS_ERROR"
+  | "EOS_NOT_IN_CACHE"
+  | "HEADER_HASH_NOT_IN_REQUEST"
+  | "HEIGHT_NOT_IN_BLOCKCHAIN"
+  | "HINT_NOT_IN_REQUEST"
+  | "INTERNAL_ERROR"
+  | "INVALID_BLOCK_OR_GENERATOR"
+  | "INVALID_COST"
+  | "INVALID_HEIGHT_FOR_COIN"
+  | "INVALID_NETWORK_SPACE_REQUEST"
+  | "NAME_NOT_IN_REQUEST"
+  | "NAMES_NOT_IN_REQUEST"
+  | "NEW_AND_OLD_MUST_DIFFER"
+  | "NEWER_BLOCK_NOT_FOUND"
+  | "NO_BLOCKS_IN_CHAIN"
+  | "NO_COIN_NAME_IN_REQUEST"
+  | "NO_END_IN_REQUEST"
+  | "NO_HEADER_HASH_IN_REQUEST"
+  | "NO_HEIGHT_IN_REQUEST"
+  | "NO_START_IN_REQUEST"
+  | "NO_TX_ID_IN_REQUEST"
+  | "OLDER_BLOCK_NOT_FOUND"
+  | "PARENT_IDS_NOT_IN_REQUEST"
+  | "PEAK_IS_NONE"
+  | "PROTOCOL_ERROR"
+  | "PUZZLE_HASH_NOT_IN_REQUEST"
+  | "PUZZLE_HASHES_NOT_IN_REQUEST"
+  | "PUZZLE_SOLUTION_FAILED"
+  | "REQUEST_MUST_CONTAIN_EXACTLY_ONE"
+  | "SP_NOT_IN_CACHE"
+  | "SPEND_BUNDLE_NOT_IN_REQUEST"
+  | "TARGET_TIMES_NON_NEGATIVE"
+  | "TARGET_TIMES_REQUIRED"
+  | "TIMESTAMP_ERROR"
+  | "TRANSACTION_FAILED"
+  | "TX_NOT_IN_MEMPOOL"
+  | "UNKNOWN"
+  | "VALIDATION_ERROR";
+
+// Structured error attached to RPC error responses as of chia-blockchain 2.6.1
+export type TStructuredError = {
+  code: TRpcErrorCode | string;
+  message: string;
+  data: Record<string, unknown>;
+};
+
 export class RpcError extends Error {
   public response: unknown;
+  public structuredError?: TStructuredError;
 
   public constructor(message: string, response: unknown) {
     super(message);
     this.name = "RpcError";
     this.response = response;
+    if (
+      response &&
+      typeof response === "object" &&
+      "structuredError" in response
+    ) {
+      this.structuredError = (
+        response as { structuredError: TStructuredError }
+      ).structuredError;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Stacked PR 4/6 (base: `v18.0.0`, see #83) — brings chia-agent to **chia-blockchain 2.6.1**. Major version bump because the `ProofOfSpace` wire format changed (chia_rs 0.38.2).

### Breaking
- `ProofOfSpace` (embedded in many full_node responses): gained `version`, `plot_index`, `meta_group`, `strength`; `size` now only carries the v1 k-size
- `PartialProof.proof_fragments` renamed to `fragments` (16 entries)

### Added
- **Structured RPC errors**: error responses now always carry `structuredError: {code, message, data}` (+ `traceback` on HTTP). `RpcError` exposes `structuredError`; added `TStructuredError` / `TRpcErrorCode` types covering all 44 upstream error codes
- `create_signed_transaction`: optional `extra_delta`, `tail_reveal`, `tail_solution`, `puzzle_decorator`
- `PartialProofsData`: added `plot_index`, `meta_group`

### Notes
- `nft_mint_nft`: upstream reverted `royalty_amount` back to `royalty_percentage` — chia-agent already matched, no change
- `take_offer`: `sign` is now ignored upstream; `did_find_lost_did` echoes the requested coin id

See the `[19.0.0]` CHANGELOG entry for the full list.

## Verification
`pnpm build`, `pnpm check:lint` and `pnpm check:prettier` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)