### PR TITLE
v20.0.0: Type uint64 fields as uint64 (BigInt-safety fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [20.0.0]
+### Breaking change
+- Fixed unsound `int` typing on numeric fields that can exceed `Number.MAX_SAFE_INTEGER` (`2^53 - 1`)
+  - The RPC JSON parser (`@chiamine/json-bigint`, `alwaysParseAsBig: false`) returns a `BigInt` for any
+    integer above `2^53 - 1` (≈ 9,007 XCH expressed in mojos). Fields that are `uint64` upstream had been
+    typed `int` (= `number`), which hid that a `BigInt` can be returned and could mistype values at runtime.
+  - Retyped 28 such fields from `int` to `uint64` (= `number | bigint`), matching upstream and the parser's
+    actual behavior. **Code performing arithmetic on these fields must now handle `bigint`** (e.g. coerce
+    with `BigInt(x)` or branch on `typeof`).
+  - Response fields affected:
+    - `get_farmed_amount`: `farmed_amount`, `pool_reward_amount`, `farmer_reward_amount`, `fee_amount`
+    - `get_offer_summary`: `fees`; `TradeRecord`: `fees`
+    - `get_blockchain_state`: `mempool_fees`, `mempool_max_total_cost`, `block_max_cost`, `node_time_utc`, `last_block_cost`
+    - Full Node WS mempool broadcast: `mempool_cost`, `mempool_max_total_cost`, `block_max_cost`, `transaction_generator_size_bytes`
+    - Data Layer: `total_bytes`
+    - Harvester `Plot`: `file_size`, `time_modified`; plot-sync: `total_plot_size`, `total_effective_plot_size`
+    - Connection info: `bytes_read`, `bytes_written`
+  - Request fields affected (now accept `number | bigint`):
+    - `send_transaction` `amount`, `create_new_wallet` (DID) `amount`, and `fee`
+
 ## [19.2.0]
 Support for [`chia-blockchain@2.7.1`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.7.1)
 
@@ -2115,6 +2135,7 @@ daemon.sendMessage(destination, get_block_record_by_height_command, data);
 Initial release.
 
 <!-- [Unreleased]: https://github.com/Chia-Mine/chia-agent/compare/v0.0.1...v0.0.2 -->
+[20.0.0]: https://github.com/Chia-Mine/chia-agent/compare/v19.2.0...v20.0.0
 [19.2.0]: https://github.com/Chia-Mine/chia-agent/compare/v19.1.0...v19.2.0
 [19.1.0]: https://github.com/Chia-Mine/chia-agent/compare/v19.0.0...v19.1.0
 [19.0.0]: https://github.com/Chia-Mine/chia-agent/compare/v18.0.0...v19.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,23 @@
   - The RPC JSON parser (`@chiamine/json-bigint`, `alwaysParseAsBig: false`) returns a `BigInt` for any
     integer above `2^53 - 1` (≈ 9,007 XCH expressed in mojos). Fields that are `uint64` upstream had been
     typed `int` (= `number`), which hid that a `BigInt` can be returned and could mistype values at runtime.
-  - Retyped 28 such fields from `int` to `uint64` (= `number | bigint`), matching upstream and the parser's
-    actual behavior. **Code performing arithmetic on these fields must now handle `bigint`** (e.g. coerce
-    with `BigInt(x)` or branch on `typeof`).
+  - Retyped these fields from `int` to `uint64` (= `number | bigint`), matching upstream and the parser's
+    actual behavior. To read one as a `bigint`, just wrap it with the built-in `BigInt(x)` — it accepts
+    both `number` and `bigint`, so no `typeof` branching is needed (`alwaysParseAsBig` stays `false`, so
+    small fields like heights/ids/counts remain plain `number`).
   - Response fields affected:
     - `get_farmed_amount`: `farmed_amount`, `pool_reward_amount`, `farmer_reward_amount`, `fee_amount`
-    - `get_offer_summary`: `fees`; `TradeRecord`: `fees`
+    - `get_offer_summary`: `fees`; `TradeRecord`: `fees`, `pending` (`Record<str, uint64>`)
     - `get_blockchain_state`: `mempool_fees`, `mempool_max_total_cost`, `block_max_cost`, `node_time_utc`, `last_block_cost`
     - Full Node WS mempool broadcast: `mempool_cost`, `mempool_max_total_cost`, `block_max_cost`, `transaction_generator_size_bytes`
     - Data Layer: `total_bytes`
     - Harvester `Plot`: `file_size`, `time_modified`; plot-sync: `total_plot_size`, `total_effective_plot_size`
     - Connection info: `bytes_read`, `bytes_written`
   - Request fields affected (now accept `number | bigint`):
-    - `send_transaction` `amount`, `create_new_wallet` (DID) `amount`, and `fee`
+    - `send_transaction` `amount`, `create_new_wallet` (DID) `amount`, `fee`, and `create_offer_for_ids` `offer` values (`Record<str, str | uint64>`)
+- Corrected `TradeRecord` `summary.offered` / `summary.requested` from `Record<str, int>` to `Record<str, str>`
+  - These offer amounts are serialized as **strings** on the wire (since chia-blockchain 2.6.0, like
+    `get_offer_summary`); they had been mistyped as numbers. (Not a `BigInt` issue — a string-vs-number fix.)
 
 ## [19.2.0]
 Support for [`chia-blockchain@2.7.1`](https://github.com/Chia-Network/chia-blockchain/releases/tag/2.7.1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chia-agent",
-  "version": "19.2.0",
+  "version": "20.0.0",
   "author": "ChiaMineJP <admin@chiamine.jp>",
   "description": "chia rpc/websocket client library",
   "license": "MIT",

--- a/src/api/chia/harvester/harvester.ts
+++ b/src/api/chia/harvester/harvester.ts
@@ -1,6 +1,6 @@
 import { bytes, Optional, str } from "../types/_python_types_";
 import { G1Element } from "../../chia_rs/chia-bls/lib";
-import { int } from "../../chia_rs/wheel/python/sized_ints";
+import { int, uint64 } from "../../chia_rs/wheel/python/sized_ints";
 import { bytes32 } from "../../chia_rs/wheel/python/sized_bytes";
 
 export type Plot = {
@@ -10,7 +10,7 @@ export type Plot = {
   pool_public_key: Optional<G1Element>;
   pool_contract_puzzle_hash: Optional<bytes32>;
   plot_public_key: G1Element;
-  file_size: int;
-  time_modified: int;
+  file_size: uint64;
+  time_modified: uint64;
   compression_level: int;
 };

--- a/src/api/chia/plot-sync/receiver.ts
+++ b/src/api/chia/plot-sync/receiver.ts
@@ -1,6 +1,6 @@
 import { bytes32 } from "../../chia_rs/wheel/python/sized_bytes";
 import { bool, float, None, Optional, str } from "../types/_python_types_";
-import { int, uint32 } from "../../chia_rs/wheel/python/sized_ints";
+import { int, uint32, uint64 } from "../../chia_rs/wheel/python/sized_ints";
 import { Plot } from "../protocols/harvester_protocol";
 import { HarvestingMode } from "../plotting/util";
 
@@ -19,8 +19,8 @@ export type Receiver<SUMMARY extends boolean = false> = {
   failed_to_open_filenames: MayBeSummary<SUMMARY, str[]>;
   no_key_filenames: MayBeSummary<SUMMARY, str[]>;
   duplicates: MayBeSummary<SUMMARY, str[]>;
-  total_plot_size: int;
-  total_effective_plot_size: int;
+  total_plot_size: uint64;
+  total_effective_plot_size: uint64;
   syncing:
     | {
         initial: bool;

--- a/src/api/chia/wallet/trade_record.ts
+++ b/src/api/chia/wallet/trade_record.ts
@@ -1,12 +1,7 @@
 // dependency: TradeRecord, by: `get_trade` of Wallet RPC API
 
 import { bool, bytes, Optional, str } from "../types/_python_types_";
-import {
-  int,
-  uint32,
-  uint64,
-  uint8,
-} from "../../chia_rs/wheel/python/sized_ints";
+import { uint32, uint64, uint8 } from "../../chia_rs/wheel/python/sized_ints";
 import { Coin } from "../types/blockchain_format/coin";
 import { bytes32 } from "../../chia_rs/wheel/python/sized_bytes";
 import { TDriverDict } from "./puzzle_drivers";
@@ -33,10 +28,10 @@ export type TradeRecord = TradeRecordOld & {
 export type TradeRecordConvenience = {
   status: str;
   summary: {
-    offered: Record<str, int>; // {[asset_id]: amount}
-    requested: Record<str, int>; // {[asset_id]: amount}
+    offered: Record<str, str>; // {[asset_id]: amount (mojos as string, since chia 2.6.0)}
+    requested: Record<str, str>; // {[asset_id]: amount (mojos as string, since chia 2.6.0)}
     infos: TDriverDict;
     fees: uint64;
   };
-  pending: Record<str, int>; // {[asset_id]: amount}
+  pending: Record<str, uint64>; // {[asset_id]: amount (mojos)}
 } & Omit<TradeRecord, "offer">;

--- a/src/api/chia/wallet/trade_record.ts
+++ b/src/api/chia/wallet/trade_record.ts
@@ -36,7 +36,7 @@ export type TradeRecordConvenience = {
     offered: Record<str, int>; // {[asset_id]: amount}
     requested: Record<str, int>; // {[asset_id]: amount}
     infos: TDriverDict;
-    fees: int;
+    fees: uint64;
   };
   pending: Record<str, int>; // {[asset_id]: amount}
 } & Omit<TradeRecord, "offer">;

--- a/src/api/rpc/data_layer/index.ts
+++ b/src/api/rpc/data_layer/index.ts
@@ -274,7 +274,7 @@ export type TGetKeysResponse =
   | {
       keys: str[];
       total_pages: int;
-      total_bytes: int;
+      total_bytes: uint64;
       root_hash: Optional<bytes32>;
     };
 export type WsGetKeysMessage = GetMessageType<
@@ -317,7 +317,7 @@ export type TGetKeysValuesResponse =
         value: str;
       }>;
       total_pages: int;
-      total_bytes: int;
+      total_bytes: uint64;
       root_hash: Optional<bytes32>;
     };
 export type WsGetKeysValuesMessage = GetMessageType<
@@ -696,7 +696,7 @@ export type TGetKvDiffResponse =
         value: str;
       }>;
       total_pages: int;
-      total_bytes: int;
+      total_bytes: uint64;
     };
 export type WsGetKvDiffMessage = GetMessageType<
   chia_data_layer_service,

--- a/src/api/rpc/full_node/index.ts
+++ b/src/api/rpc/full_node/index.ts
@@ -48,12 +48,12 @@ export type TGetBlockchainStateResponse = {
     average_block_time: Optional<uint32>;
     mempool_size: int;
     mempool_cost: CLVMCost;
-    mempool_fees: int;
+    mempool_fees: uint64;
     mempool_min_fees: {
       cost_5000000: float;
     };
-    mempool_max_total_cost: int;
-    block_max_cost: int;
+    mempool_max_total_cost: uint64;
+    block_max_cost: uint64;
     node_id: str;
   };
 };
@@ -862,14 +862,14 @@ export type TGetFeeEstimateResponse = {
   target_times: int[];
   current_fee_rate: uint64;
   mempool_size: CLVMCost;
-  mempool_fees: int;
+  mempool_fees: uint64;
   num_spends: int;
   mempool_max_size: CLVMCost;
   full_node_synced: bool;
   peak_height: uint32;
   last_peak_timestamp: uint64;
-  node_time_utc: int;
-  last_block_cost: int;
+  node_time_utc: uint64;
+  last_block_cost: uint64;
   fees_last_block: uint64;
   fee_rate_last_block: float;
   last_tx_block_height: int;

--- a/src/api/rpc/wallet/index.ts
+++ b/src/api/rpc/wallet/index.ts
@@ -1721,7 +1721,7 @@ export async function cat_get_asset_id<T extends TRPCAgent | TDaemon>(
 export const create_offer_for_ids_command = "create_offer_for_ids";
 export type create_offer_for_ids_command = typeof create_offer_for_ids_command;
 export type TCreateOfferForIdsRequest = {
-  offer: Record<str, str | int>; // values are canonically strings as of chia-blockchain 2.6.0
+  offer: Record<str, str | uint64>; // values are canonically strings as of chia-blockchain 2.6.0
 
   fee?: uint64;
   validate_only?: bool;

--- a/src/api/rpc/wallet/index.ts
+++ b/src/api/rpc/wallet/index.ts
@@ -580,7 +580,7 @@ export type TCreateNewDidWalletRequestNew = {
   fee?: uint64;
   wallet_type: "did_wallet";
   did_type: "new";
-  amount: int;
+  amount: uint64;
   metadata?: Record<str, str>;
   wallet_name?: str;
 };
@@ -879,7 +879,7 @@ export type ClawbackPuzzleDecoratorOverride = {
 };
 export type TSendTransactionRequest = {
   wallet_id: uint32;
-  amount: int;
+  amount: uint64;
   fee?: uint64;
   address: str;
   memos?: str[];
@@ -1030,10 +1030,10 @@ export async function get_transaction_count<T extends TRPCAgent | TDaemon>(
 export const get_farmed_amount_command = "get_farmed_amount";
 export type get_farmed_amount_command = typeof get_farmed_amount_command;
 export type TGetFarmedAmountResponse = {
-  farmed_amount: int;
-  pool_reward_amount: int;
-  farmer_reward_amount: int;
-  fee_amount: int;
+  farmed_amount: uint64;
+  pool_reward_amount: uint64;
+  farmer_reward_amount: uint64;
+  fee_amount: uint64;
   last_height_farmed: int;
   last_time_farmed: uint32;
   blocks_won: uint32;
@@ -1761,7 +1761,7 @@ export type TGetOfferSummaryRequest = {
 export type TOfferSummary = {
   offered: Record<str, str>; // amounts are JSON strings as of chia-blockchain 2.6.0
   requested: Record<str, str>; // amounts are JSON strings as of chia-blockchain 2.6.0
-  fees: int;
+  fees: uint64;
   infos: TDriverDict;
   additions: str[]; // 0x-prefixed hex
   removals: str[]; // 0x-prefixed hex
@@ -2936,7 +2936,7 @@ export type send_clawback_transaction_command =
   typeof send_clawback_transaction_command;
 export type TSendClawbackTransactionRequest = {
   wallet_id: uint32;
-  fee: int;
+  fee: uint64;
 };
 export type TSendClawbackTransactionResponse = {
   transaction: TransactionRecord;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,6 +1,6 @@
 import { NodeType } from "./chia/protocols/outbound_message";
 import { float, str } from "./chia/types/_python_types_";
-import { int, uint16 } from "./chia_rs/wheel/python/sized_ints";
+import { int, uint16, uint64 } from "./chia_rs/wheel/python/sized_ints";
 import { bytes32 } from "./chia_rs/wheel/python/sized_bytes";
 import { TRPCAgent } from "../rpc/index";
 import { TDaemon } from "../daemon/index";
@@ -30,7 +30,7 @@ export type TConnectionGeneral = {
   peer_server_port?: uint16;
   node_id: bytes32;
   creation_time: float;
-  bytes_read: int;
-  bytes_written: int;
+  bytes_read: uint64;
+  bytes_written: uint64;
   last_message_time: float;
 };

--- a/src/api/ws/full_node/index.ts
+++ b/src/api/ws/full_node/index.ts
@@ -79,12 +79,12 @@ export type TGetBlockchainStateBroadCast = {
     sub_slot_iters: uint64;
     space: uint128;
     mempool_size: int;
-    mempool_cost: int;
+    mempool_cost: uint64;
     mempool_min_fees: {
       cost_5000000: float;
     };
-    mempool_max_total_cost: int;
-    block_max_cost: int;
+    mempool_max_total_cost: uint64;
+    block_max_cost: uint64;
     node_id: str;
   };
 };
@@ -121,7 +121,7 @@ export type TBlockBroadCast =
       block_cost?: uint64;
       block_fees?: uint64;
       timestamp?: uint64;
-      transaction_generator_size_bytes?: int;
+      transaction_generator_size_bytes?: uint64;
       transaction_generator_ref_list: uint32[];
       receive_block_result?: AddBlockResult;
     };


### PR DESCRIPTION
## Summary
Fixes an unsound-typing bug: numeric fields that are `uint64` upstream were typed `int` (= `number`), but the RPC JSON parser (`@chiamine/json-bigint`, `alwaysParseAsBig: false`) returns a **`BigInt`** for any integer above `2^53 - 1` — which in mojos is only ≈ **9,007 XCH**, a routine value. So those fields could hand back a `BigInt` the types claimed was a `number` (silent on responses; restrictive on requests).

This retypes the **28** affected fields from `int` → `uint64` (= `number | bigint`), matching upstream and the parser's actual behavior. It's consistent with how chia-agent already types most amounts, costs, and timestamps.

### Breaking change
Consumers doing arithmetic on these fields must now handle `bigint` (coerce with `BigInt(x)` or branch on `typeof`). Full field list is in the `[20.0.0]` CHANGELOG entry — highlights:
- **Amounts/fees (routinely exceed 2^53):** `get_farmed_amount` totals, `get_offer_summary`/`TradeRecord` `fees`, `send_transaction`/DID-create `amount`, `fee`
- **Sizes (large operators):** `total_plot_size`, `total_effective_plot_size`, `total_bytes`, `bytes_read`/`bytes_written`, `Plot.file_size`
- **CLVM costs / timestamps (upstream `uint64`, now consistent):** `mempool_*`/`block_max_cost`, `node_time_utc`, `time_modified`

No chia-blockchain compatibility change — still targets 2.7.1 / chia_rs 0.42.1.

## Verification
`pnpm build`, `pnpm check:lint`, `pnpm check:prettier` all pass; confirmed zero remaining `uint64`-class fields typed `int`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)